### PR TITLE
Added redirect if offcanvas login failed

### DIFF
--- a/woocommerce/js/woocommerce.js
+++ b/woocommerce/js/woocommerce.js
@@ -1,4 +1,5 @@
 jQuery(function ($) {
+  
   // Single add to cart button
   $('.single_add_to_cart_button:not(.product_type_variable):not(.product_type_external):not(.product_type_grouped)').attr('data-bs-toggle', 'offcanvas').attr('data-bs-target', '#offcanvas-cart');
   // Single add to cart button END
@@ -13,12 +14,6 @@ jQuery(function ($) {
   });
   // Add loading class to offcanvas-cart END
 
-  // Keep offcanvas-user open on reload if contains login or register error alert
-  if ($('#offcanvas-user .alert').length > 0) {
-    $('#offcanvas-user').offcanvas('show');
-  }
-  // Keep offcanvas-user open on reload if contains login or register error alert END
-
   // Review Checkbox Products
   $('.comment-form-cookies-consent').addClass('form-check');
   $('#wp-comment-cookies-consent').addClass('form-check-input');
@@ -31,4 +26,5 @@ jQuery(function ($) {
     $('.woocommerce form .form-row.woocommerce-invalid .select2-container, .woocommerce form .form-row.woocommerce-invalid input.input-text, .woocommerce form .form-row.woocommerce-invalid select, .woocommerce form .form-row.woocommerce-invalid .form-check-input[type=checkbox]').removeClass('is-valid').addClass('is-invalid');
   });
   // Checkout Form Validation END
+  
 }); // jQuery End

--- a/woocommerce/myaccount/my-account-offcanvas.php
+++ b/woocommerce/myaccount/my-account-offcanvas.php
@@ -10,9 +10,6 @@ if (!defined('ABSPATH')) {
 
 ?>
 
-<!-- Error notice if login failed -->
-<?php wc_print_notices(); ?>
-
 <?php if (is_user_logged_in()) { ?>
 
   <div class="account-salution">

--- a/woocommerce/woocommerce-functions.php
+++ b/woocommerce/woocommerce-functions.php
@@ -242,7 +242,7 @@ function bootscore_wc_capture_hook_output($hookName) {
 
 // Redirect to my-account if offcanvas login failed
 add_action( 'woocommerce_login_failed', 'bootscore_redirect_on_login_failed' , 10, 0 );
-function bootscore_redirect_on_login_failed() : void {
+function bootscore_redirect_on_login_failed() {
   // Logout user doesn't have session, we need this to display notices
   if ( ! WC()->session->has_session() ) {
     WC()->session->set_customer_session_cookie( true );

--- a/woocommerce/woocommerce-functions.php
+++ b/woocommerce/woocommerce-functions.php
@@ -184,6 +184,7 @@ function custom_loop_product_thumbnail() {
 // Add card-img-top class to product loop End
 
 
+// Correct hooked checkboxes in checkout
 /**
  * Get the corrected terms for Woocommerce.
  *
@@ -236,3 +237,26 @@ function bootscore_wc_capture_hook_output($hookName) {
   ob_end_clean();
   return $hookContent;
 }
+// Correct hooked checkboxes in checkout End
+
+
+// Redirect to my-account if offcanvas login failed
+add_action( 'woocommerce_login_failed', 'bootscore_redirect_on_login_failed' , 10, 0 );
+function bootscore_redirect_on_login_failed() : void {
+  // Logout user doesn't have session, we need this to display notices
+  if ( ! WC()->session->has_session() ) {
+    WC()->session->set_customer_session_cookie( true );
+  }
+  wp_redirect( wp_validate_redirect( wc_get_page_permalink( 'myaccount' ) ) );
+    exit;
+}
+// Redirect to my-account if offcanvas login failed End
+
+
+// Redirect to home on logout
+add_action('wp_logout','bootscore_redirect_after_logout');
+function bootscore_redirect_after_logout(){
+  wp_redirect( home_url() );
+  exit();
+}
+// Redirect to home on logout End

--- a/woocommerce/woocommerce-functions.php
+++ b/woocommerce/woocommerce-functions.php
@@ -241,22 +241,22 @@ function bootscore_wc_capture_hook_output($hookName) {
 
 
 // Redirect to my-account if offcanvas login failed
-add_action( 'woocommerce_login_failed', 'bootscore_redirect_on_login_failed' , 10, 0 );
+add_action('woocommerce_login_failed', 'bootscore_redirect_on_login_failed', 10, 0);
 function bootscore_redirect_on_login_failed() {
   // Logout user doesn't have session, we need this to display notices
-  if ( ! WC()->session->has_session() ) {
-    WC()->session->set_customer_session_cookie( true );
+  if (!WC()->session->has_session()) {
+    WC()->session->set_customer_session_cookie(true);
   }
-  wp_redirect( wp_validate_redirect( wc_get_page_permalink( 'myaccount' ) ) );
-    exit;
+  wp_redirect(wp_validate_redirect(wc_get_page_permalink('myaccount')));
+  exit;
 }
 // Redirect to my-account if offcanvas login failed End
 
 
 // Redirect to home on logout
-add_action('wp_logout','bootscore_redirect_after_logout');
-function bootscore_redirect_after_logout(){
-  wp_redirect( home_url() );
+add_action('wp_logout', 'bootscore_redirect_after_logout');
+function bootscore_redirect_after_logout() {
+  wp_redirect(home_url());
   exit();
 }
 // Redirect to home on logout End


### PR DESCRIPTION
Closes #35 

This PR removes the hook for alerts in user offcanvas and redirects to my-account page if login failed.

### Motivation

Before logged in via user offcanvas and entered a wrong password or username, offcanvas stayed open and alert was displayed inside offcanvas. This makes problems if a user edited data in dashboard. For example when changing the address, the alert for failed or success were shown in offcanvas too.

Now the hook for alerts is removed and user will be redirect to my-account page when login failed instead and alert is shown there. 

- Redirect to my-account page after login in offcanvas failed
- Redirect to my-account page after login in checkout failed
- Redirect to home page after logout
- Alerts in dashboard are shown in the top of the page when changing data there

### Test

Code is already live on [bootscore.me](https://bootscore.me). 

- Try to login with wrong user or/and password, you will be redirected to my-account page and get a feedback there what's wrong. 
- Login in user offcanvas with correct user and password. 
- Click in user offcanvas to Addresses and change something. Alert will be shown on top of the page if failed or success.
- Click Logout in user offcanvas and you will be redirected to home page.




