### PR TITLE
Force scss compile when environment is development

### DIFF
--- a/inc/scss-compiler.php
+++ b/inc/scss-compiler.php
@@ -35,8 +35,10 @@ function bootscore_compile_scss() {
   $last_modified = bootscore_get_last_modified_scss($theme_directory);
   $stored_modified = get_theme_mod('bootscore_scss_modified_timestamp', 0);
 
+  $is_environment_dev = (wp_get_environment_type() === 'development');
+
   try {
-    if ($last_modified > $stored_modified || !file_exists($css_file)) {
+    if ($last_modified > $stored_modified || !file_exists($css_file) || $is_environment_dev) {
       $compiled = $compiler->compileString(file_get_contents($scss_file));
 
       if (!file_exists(dirname($css_file))) {


### PR DESCRIPTION
When `wp_get_environment_type()` returns that it is in development mode, either from reading the `define` in the wp-config.php or from reading the `getenv`, the scss will always be compiled, no matter if changes have been made.

To set the environment to development, add the following line to your wp-config.php
`define('WP_ENVIRONMENT_TYPE', 'development');`

This PR has been made in response to comments from @Axos11 on #33 