### PR TITLE
Woocommerce-style.css to scss part 1

### DIFF
--- a/css/scss/_bscore_custom.scss
+++ b/css/scss/_bscore_custom.scss
@@ -1,7 +1,3 @@
-/*!
- * Custom styles
- */
-
 // Add your own code here!
 // Because this file is compiled after Bootstrap, you're also able to use Bootstrap mixins for better code.
 // Some examples can be found here: https://bootscore.me/documentation/bootstrap-css-sass

--- a/css/scss/_bscore_custom.scss
+++ b/css/scss/_bscore_custom.scss
@@ -1,3 +1,7 @@
+/*!
+ * Custom styles
+ */
+
 // Add your own code here!
 // Because this file is compiled after Bootstrap, you're also able to use Bootstrap mixins for better code.
 // Some examples can be found here: https://bootscore.me/documentation/bootstrap-css-sass

--- a/css/scss/_bscore_style.scss
+++ b/css/scss/_bscore_style.scss
@@ -1,5 +1,5 @@
 /*!
- * Bootscore v5.2.0.0 (https://bootscore.me/)
+ * bootScore v5.2.0.0 (https://bootscore.me/)
  */
  
 @import "bootscore/alerts";

--- a/css/scss/_bscore_style.scss
+++ b/css/scss/_bscore_style.scss
@@ -1,5 +1,5 @@
 /*!
- * bootScore v5.2.0.0 (https://bootscore.me/)
+ * bootScore 5.1.3.1 (https://bootscore.me/)
  */
  
 @import "bootscore/alerts";

--- a/css/scss/_bscore_woocommerce.scss
+++ b/css/scss/_bscore_woocommerce.scss
@@ -1,0 +1,4 @@
+/*!
+ * Bootscore WooCommerce v5.2.0.0 (https://bootscore.me/)
+ * Content from woocommerce-style.css will later be placed here and woocommerce-style.css will be deleted.
+ */

--- a/css/scss/_bscore_woocommerce.scss
+++ b/css/scss/_bscore_woocommerce.scss
@@ -1,4 +1,4 @@
 /*!
- * Bootscore WooCommerce v5.2.0.0 (https://bootscore.me/)
+ * bootScore WooCommerce v5.2.0.0 (https://bootscore.me/)
  * Content from woocommerce-style.css will later be placed here and woocommerce-style.css will be deleted.
  */

--- a/css/scss/_bscore_woocommerce.scss
+++ b/css/scss/_bscore_woocommerce.scss
@@ -1,4 +1,4 @@
 /*!
- * bootScore WooCommerce v5.2.0.0 (https://bootscore.me/)
+ * bootScore WooCommerce 5.1.3.1 (https://bootscore.me/)
  * Content from woocommerce-style.css will later be placed here and woocommerce-style.css will be deleted.
  */

--- a/css/scss/bootstrap.min.scss
+++ b/css/scss/bootstrap.min.scss
@@ -1,5 +1,6 @@
 @import "bscore_variables";
 @import "bootstrap/bootstrap";
 @import "bscore_style";
+//@import "bscore_woocommerce"; // Remove comments to activate WooCommerce styles
 @import "bscore_custom";
 @import "fontawesome";

--- a/css/scss/bootstrap.min.scss
+++ b/css/scss/bootstrap.min.scss
@@ -3,4 +3,3 @@
 @import "bscore_style";
 //@import "bscore_woocommerce"; // Remove comments to activate WooCommerce styles
 @import "bscore_custom";
-@import "fontawesome";


### PR DESCRIPTION
This PR adds a (still empty) `_bscore_woocommerce.scss` collector file and prepares to merge the `woocommerce-style.css` to scss like we did with style.css. This file is deactivated in parent `_bootstrap.min.scss` and can be activated by removing the comments. bootcommerce-child has activated this file by default Pull request [#5](https://github.com/bootscore/bootcommerce-child/pull/5).

File is loaded before `_bscore_custom.scss` and can easily be overwritten.

We should users give time to add this file by `@import` on their existing bootcommerce-child theme installation. In 5.2.1.0 we can move content from `woocommerce-style.css` to scss safely.