### PR TITLE
Fix accessibility issues

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -91,7 +91,7 @@
 </footer>
 
 <div class="top-button position-fixed zi-1020">
-  <a href="#to-top" class="btn btn-primary shadow"><i class="fas fa-chevron-up"></i></a>
+  <a href="#to-top" class="btn btn-primary shadow"><i class="fas fa-chevron-up"></i><span class="visually-hidden-focusable">To top</span></a>
 </div>
 
 </div><!-- #page -->

--- a/header-woocommerce.php
+++ b/header-woocommerce.php
@@ -8,6 +8,8 @@
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
  * @package Bootscore
+ * 
+ * @version 5.1.3.1
  */
 
 ?>

--- a/header-woocommerce.php
+++ b/header-woocommerce.php
@@ -85,17 +85,17 @@
 
               <!-- Search Toggler -->
               <button class="btn btn-outline-secondary ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
-                <i class="fas fa-search"></i>
+                <i class="fas fa-search"></i><span class="visually-hidden-focusable">Search</span>
               </button>
 
               <!-- User Toggler -->
               <button class="btn btn-outline-secondary ms-1 ms-md-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-user" aria-controls="offcanvas-user">
-                <i class="fas fa-user"></i>
+                <i class="fas fa-user"></i><span class="visually-hidden-focusable">Account</span>
               </button>
 
               <!-- Mini Cart Toggler -->
               <button class="btn btn-outline-secondary ms-1 ms-md-2 position-relative" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-cart" aria-controls="offcanvas-cart">
-                <i class="fas fa-shopping-bag"></i>
+                <i class="fas fa-shopping-bag"></i><span class="visually-hidden-focusable">Cart</span>
                 <?php if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
                   $count = WC()->cart->cart_contents_count;
                 ?>
@@ -110,7 +110,7 @@
 
               <!-- Navbar Toggler -->
               <button class="btn btn-outline-secondary d-lg-none ms-1 ms-md-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-navbar" aria-controls="offcanvas-navbar">
-                <i class="fas fa-bars"></i>
+                <i class="fas fa-bars"></i><span class="visually-hidden-focusable">Menu</span>
               </button>
 
             </div><!-- .header-actions -->

--- a/header.php
+++ b/header.php
@@ -8,6 +8,8 @@
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
  * @package Bootscore
+ * 
+ * @version 5.1.3.1
  */
 
 ?>

--- a/header.php
+++ b/header.php
@@ -95,12 +95,12 @@
 
               <!-- Search Toggler Mobile -->
               <button class="btn btn-outline-secondary d-lg-none ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
-                <i class="fas fa-search"></i>
+                <i class="fas fa-search"></i><span class="visually-hidden-focusable">Search</span>
               </button>
 
               <!-- Navbar Toggler -->
               <button class="btn btn-outline-secondary d-lg-none ms-1 ms-md-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-navbar" aria-controls="offcanvas-navbar">
-                <i class="fas fa-bars"></i>
+                <i class="fas fa-bars"></i><span class="visually-hidden-focusable">Menu</span>
               </button>
 
             </div><!-- .header-actions -->

--- a/searchform.php
+++ b/searchform.php
@@ -1,5 +1,5 @@
 <!-- Search Button Outline Secondary Right -->
 <form class="searchform input-group" method="get" action="<?php echo esc_url(home_url('/')); ?>" class="form-inline">
   <input type="text" name="s" class="form-control" placeholder="<?php _e('Search', 'bootscore'); ?>">
-  <button type="submit" class="input-group-text btn btn-outline-secondary"><i class="fas fa-search"></i></button>
+  <button type="submit" class="input-group-text btn btn-outline-secondary"><i class="fas fa-search"></i><span class="visually-hidden-focusable">Search</span></button>
 </form>

--- a/woocommerce/product-searchform.php
+++ b/woocommerce/product-searchform.php
@@ -25,8 +25,8 @@ if (!defined('ABSPATH')) {
 <form role="search" method="get" class="searchform woocommerce-product-search" action="<?php echo esc_url(home_url('/')); ?>">
   <div class="input-group">
     <input class="form-control" type="search" id="woocommerce-product-search-field-<?php echo isset($index) ? absint($index) : 0; ?>" class="search-field field form-control" placeholder="<?php echo esc_attr__('Search products...', 'woocommerce'); ?>" value="<?php echo get_search_query(); ?>" name="s" />
-    <label class="sr-only" for="woocommerce-product-search-field-<?php echo isset($index) ? absint($index) : 0; ?>"><?php esc_html_e('Search for:', 'woocommerce'); ?></label>
+    <label class="visually-hidden-focusable" for="woocommerce-product-search-field-<?php echo isset($index) ? absint($index) : 0; ?>"><?php esc_html_e('Search for:', 'woocommerce'); ?></label>
     <input type="hidden" name="post_type" value="product" />
-    <button class="input-group-text btn btn-outline-secondary" type="submit"><i class="fas fa-search"></i></button>
+    <button class="input-group-text btn btn-outline-secondary" type="submit"><i class="fas fa-search"></i><span class="visually-hidden-focusable">Search</span></button>
   </div>
 </form>


### PR DESCRIPTION
It's not possible to add a `<label>` to searchform.php because form has no id. The searchform can't have an id because it will be displayed twice if it is in the top-nav-search widget position, mobile and large. In this case the id will be double. So, still remaining two accessibility errors.