### PR TITLE
Remove self closing offcanvas snippet

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -10,10 +10,6 @@
 --------------------------------------------------------------*/
 
 jQuery(function ($) {
-  // Hide offcanvas menu in navbar and enable body scroll on resize through the breakpoints
-  $(window).on('resize', function () {
-    $('.navbar .offcanvas').offcanvas('hide');
-  });
 
   // Close offcanvas on click a, keep .dropdown-menu open
   $('.offcanvas a:not(.dropdown-toggle):not(a.remove_from_cart_button), a.dropdown-item').on('click', function () {


### PR DESCRIPTION
Closes #71 

This PR removes the self-closing offcanvas in navbar on resize workaround, which became buggy in iOS 15.

- Navbar offcanvas will do not close on resize anymore
- When resize through the breakpoints, backdrop remains visible and body scroll locked
- Will be fixed by https://github.com/twbs/bootstrap/issues/35594