### PR TITLE
Fix for scss .map when using subdirectory

### DIFF
--- a/inc/scss-compiler.php
+++ b/inc/scss-compiler.php
@@ -40,9 +40,9 @@ function bootscore_compile_scss() {
 
   if ($is_environment_dev) {
     $compiler->setSourceMapOptions([
-      'sourceMapURL'      => '/' . substr(str_replace(ABSPATH, '', $css_file), 0, -3) . 'map',
+      'sourceMapURL'      => site_url( '', 'relative') . '/' . substr(str_replace(ABSPATH, '', $css_file), 0, -3) . 'map',
       'sourceMapBasepath' => substr(str_replace('\\', '/', ABSPATH), 0, -1),
-      'sourceRoot' => '/',
+      'sourceRoot' => site_url( '', 'relative') . '/',
     ]);
   }
 


### PR DESCRIPTION
This should fix #103. @crftwrk could you try this out on the installations you stumbled upon this issue? I've tried it in a test environment, and it seems to work fine now.