### PR TITLE
Add clear: both; to related products

### DIFF
--- a/scss/bootscore_woocommerce/_wc_product.scss
+++ b/scss/bootscore_woocommerce/_wc_product.scss
@@ -40,3 +40,9 @@ WooCommerce Product Page
 .woocommerce table.shop_attributes td {
   font-style: normal;
 }
+
+
+// Fix related products if no product tab (disabled reviews, no product description, no attributes) is used
+.related.products {
+  clear: both;
+}


### PR DESCRIPTION
Closes https://github.com/bootscore/bootscore/issues/118

Fixes related products if no product tab (disabled reviews, no product description, no attributes) is used