### PR TITLE
Register ajax cart to pluggable function

### DIFF
--- a/woocommerce/woocommerce-functions.php
+++ b/woocommerce/woocommerce-functions.php
@@ -27,10 +27,14 @@ function bootscore() {
 
 
 // Register Ajax Cart
-function register_ajax_cart() {
-  require_once('ajax-cart/ajax-add-to-cart.php');
-}
-add_action('after_setup_theme', 'register_ajax_cart');
+if (!function_exists('register_ajax_cart')) :
+
+  function register_ajax_cart() {
+    require_once('ajax-cart/ajax-add-to-cart.php');
+  }
+  add_action('after_setup_theme', 'register_ajax_cart');
+
+endif;
 // Register Ajax Cart End
 
 


### PR DESCRIPTION
This PR turns the register ajax-add-to-cart.php to a pluggable function. If someone want to create an affiliate shop, it's possible to disable ajax cart by using empty function in child:

```php
// Disable Ajax Cart
function register_ajax_cart() {
  
}
add_action('after_setup_theme', 'register_ajax_cart');
```