### PR TITLE
Improve admin bar

### DIFF
--- a/scss/_bscore_style.scss
+++ b/scss/_bscore_style.scss
@@ -7,6 +7,7 @@
 @import "bootscore/breadcrumb";
 @import "bootscore/colors";
 @import "bootscore/comments";
+@import "bootscore/footer";
 @import "bootscore/forms";
 @import "bootscore/header";
 @import "bootscore/markups";

--- a/scss/_bscore_style.scss
+++ b/scss/_bscore_style.scss
@@ -2,6 +2,7 @@
  * bootScore 5.2.0.0 (https://bootscore.me/)
  */
 
+@import "bootscore/admin_bar";
 @import "bootscore/alerts";
 @import "bootscore/archive";
 @import "bootscore/breadcrumb";

--- a/scss/bootscore/_admin_bar.scss
+++ b/scss/bootscore/_admin_bar.scss
@@ -1,0 +1,52 @@
+/*--------------------------------------------------------------
+Admin bar
+--------------------------------------------------------------*/
+
+// Mobile
+@media (max-width: 782px) {
+  // Fixed admin-bar
+  #wpadminbar {
+    position: fixed;
+  }
+
+  .logged-in.admin-bar {
+    // Push content down when WP admin-bar is visible
+    .fixed-top,
+    .offcanvas:not(.offcanvas-bottom),
+    .modal-dialog {
+      top: 46px;
+    }
+
+    // Adjust modal height
+    .modal-fullscreen,
+    .modal-fullscreen-sm-down,
+    .modal-fullscreen-md-down,
+    .modal-fullscreen-lg-down,
+    .modal-fullscreen-xl-down,
+    .modal-fullscreen-xxl-down {
+      height: calc(100% - 46px);
+    }
+  }
+}
+
+// Desktop
+@media (min-width: 783px) {
+  .logged-in.admin-bar {
+    // Push content down when WP admin-bar is visible
+    .fixed-top,
+    .offcanvas:not(.offcanvas-bottom),
+    .modal-dialog {
+      top: 32px;
+    }
+
+    // Adjust modal height
+    .modal-fullscreen,
+    .modal-fullscreen-sm-down,
+    .modal-fullscreen-md-down,
+    .modal-fullscreen-lg-down,
+    .modal-fullscreen-xl-down,
+    .modal-fullscreen-xxl-down {
+      height: calc(100% - 32px);
+    }
+  }
+}

--- a/scss/bootscore/_footer.scss
+++ b/scss/bootscore/_footer.scss
@@ -1,0 +1,19 @@
+/*--------------------------------------------------------------
+Footer
+--------------------------------------------------------------*/
+
+// Make the footer stick to the bottom
+html,
+body,
+#page {
+  height: 100%;
+}
+
+#page {
+  display: flex;
+  flex-direction: column;
+}
+
+#content {
+  flex: 1;
+}

--- a/scss/bootscore/_header.scss
+++ b/scss/bootscore/_header.scss
@@ -7,55 +7,6 @@ html {
   scroll-padding-top: 55px;
 }
 
-// Mobile
-@media (max-width: 782px) {
-  // Fixed admin-bar
-  #wpadminbar {
-    position: fixed;
-  }
-
-  .logged-in.admin-bar {
-    // Push content down when WP admin-bar is visible
-    .fixed-top,
-    .offcanvas:not(.offcanvas-bottom),
-    .modal-dialog {
-      top: 46px;
-    }
-
-    // Adjust modal height
-    .modal-fullscreen,
-    .modal-fullscreen-sm-down,
-    .modal-fullscreen-md-down,
-    .modal-fullscreen-lg-down,
-    .modal-fullscreen-xl-down,
-    .modal-fullscreen-xxl-down {
-      height: calc(100% - 46px);
-    }
-  }
-}
-
-// Desktop
-@media (min-width: 783px) {
-  .logged-in.admin-bar {
-    // Push content down when WP admin-bar is visible
-    .fixed-top,
-    .offcanvas:not(.offcanvas-bottom),
-    .modal-dialog {
-      top: 32px;
-    }
-
-    // Adjust modal height
-    .modal-fullscreen,
-    .modal-fullscreen-sm-down,
-    .modal-fullscreen-md-down,
-    .modal-fullscreen-lg-down,
-    .modal-fullscreen-xl-down,
-    .modal-fullscreen-xxl-down {
-      height: calc(100% - 32px);
-    }
-  }
-}
-
 // Reset Bootstrap last nav-bar nav-link padding
 #nav-main .menu-item:last-child .nav-link {
   padding-right: 0;

--- a/scss/bootscore/_markups.scss
+++ b/scss/bootscore/_markups.scss
@@ -9,22 +9,6 @@ body {
   overflow-x: hidden;
 }
 
-// Make the footer stick to the bottom
-html,
-body,
-#page {
-  height: 100%;
-}
-
-#page {
-  display: flex;
-  flex-direction: column;
-}
-
-#content {
-  flex: 1;
-}
-
 //HTML Markups (Theme Unit Test Data)
 
 pre {


### PR DESCRIPTION
- Added `_admin_bar.scss`
- Moved `.logged-in.admin-bar` from `_header.scss` to `_admin_bar.scss`
- Added `_footer.scss`
- Moved sticky footer from `_markups.scss` to `_footer.scss`

We can handle sticky footer if user is logged in in `_admin_bar.scss` later.