### PR TITLE
Offcanvas cart-items to list-group-flush

### DIFF
--- a/scss/bootscore_woocommerce/_wc_offcanvas_cart.scss
+++ b/scss/bootscore_woocommerce/_wc_offcanvas_cart.scss
@@ -4,7 +4,8 @@ Offcanvas Cart
 
 // Height cart-footer
 #offcanvas-cart .cart-list {
-  padding-bottom: 208px;
+  height: calc(100% - 214px); // Height cart-footer
+  overflow-y: auto;
 }
 
 // Cart loader

--- a/scss/bootscore_woocommerce/_wc_offcanvas_cart.scss
+++ b/scss/bootscore_woocommerce/_wc_offcanvas_cart.scss
@@ -2,15 +2,28 @@
 Offcanvas Cart
 --------------------------------------------------------------*/
 
-#offcanvas-cart .cart-list {
-  height: calc(100% - 214px); // Height cart-footer
-  overflow-y: auto;
+#offcanvas-cart {
+  .cart-list {
+    height: 100%;
+  }
+
+  .widget_shopping_cart_content {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .woocommerce-mini-cart {
+    flex: 1;
+    overflow-y: auto;
+  }
 }
 
 // Cart loader
 .cart-loader {
   top: 56px;
   z-index: 1;
+
   .loader-icon {
     margin-top: -56px;
   }
@@ -23,6 +36,7 @@ Offcanvas Cart
     transition: opacity 0.3s, visibility 0.3s;
     transition-delay: 0.1s;
   }
+
   &.loading .cart-loader {
     opacity: 1;
     visibility: visible;

--- a/scss/bootscore_woocommerce/_wc_offcanvas_cart.scss
+++ b/scss/bootscore_woocommerce/_wc_offcanvas_cart.scss
@@ -23,6 +23,7 @@ Offcanvas Cart
 .cart-loader {
   top: 56px;
   z-index: 1;
+  overflow: hidden; // Stop Apple Safari flickering when .widget_shopping_cart_content reached 100% height
 
   .loader-icon {
     margin-top: -56px;

--- a/scss/bootscore_woocommerce/_wc_offcanvas_cart.scss
+++ b/scss/bootscore_woocommerce/_wc_offcanvas_cart.scss
@@ -2,7 +2,6 @@
 Offcanvas Cart
 --------------------------------------------------------------*/
 
-// Height cart-footer
 #offcanvas-cart .cart-list {
   height: calc(100% - 214px); // Height cart-footer
   overflow-y: auto;

--- a/woocommerce/cart/mini-cart.php
+++ b/woocommerce/cart/mini-cart.php
@@ -102,7 +102,7 @@ do_action('woocommerce_before_mini_cart'); ?>
     ?>
   </div>
 
-  <div class="cart-footer bg-light text-center position-absolute bottom-0 p-3 w-100">
+  <div class="cart-footer bg-light text-center p-3">
 
     <p class="woocommerce-mini-cart__total total">
       <?php

--- a/woocommerce/cart/mini-cart.php
+++ b/woocommerce/cart/mini-cart.php
@@ -24,7 +24,7 @@ do_action('woocommerce_before_mini_cart'); ?>
 
 <?php if (!WC()->cart->is_empty()) : ?>
 
-  <div class="woocommerce-mini-cart cart_list product_list_widget <?php echo esc_attr($args['list_class']); ?>">
+  <div class="woocommerce-mini-cart cart_list product_list_widget list-group list-group-flush <?php echo esc_attr($args['list_class']); ?>">
     <?php
     do_action('woocommerce_before_mini_cart_contents');
 
@@ -38,7 +38,7 @@ do_action('woocommerce_before_mini_cart'); ?>
         $product_price     = apply_filters('woocommerce_cart_item_price', WC()->cart->get_product_price($_product), $cart_item, $cart_item_key);
         $product_permalink = apply_filters('woocommerce_cart_item_permalink', $_product->is_visible() ? $_product->get_permalink($cart_item) : '', $cart_item, $cart_item_key);
     ?>
-        <div class="woocommerce-mini-cart-item border-bottom p-3 <?php echo esc_attr(apply_filters('woocommerce_mini_cart_item_class', 'mini_cart_item', $cart_item, $cart_item_key)); ?>">
+        <div class="woocommerce-mini-cart-item list-group-item <?php echo esc_attr(apply_filters('woocommerce_mini_cart_item_class', 'mini_cart_item', $cart_item, $cart_item_key)); ?>">
 
           <div class="row">
 

--- a/woocommerce/cart/mini-cart.php
+++ b/woocommerce/cart/mini-cart.php
@@ -43,17 +43,15 @@ do_action('woocommerce_before_mini_cart'); ?>
           <div class="row">
 
             <div class="item-image col-3">
-              <div class="mt-1">
-                <?php if (empty($product_permalink)) : ?>
+              <?php if (empty($product_permalink)) : ?>
+                <?php echo $thumbnail; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
+                ?>
+              <?php else : ?>
+                <a href="<?php echo esc_url($product_permalink); ?>">
                   <?php echo $thumbnail; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
                   ?>
-                <?php else : ?>
-                  <a href="<?php echo esc_url($product_permalink); ?>">
-                    <?php echo $thumbnail; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
-                    ?>
-                  </a>
-                <?php endif; ?>
-              </div>
+                </a>
+              <?php endif; ?>
             </div>
 
             <div class="item-name col-7">
@@ -62,9 +60,9 @@ do_action('woocommerce_before_mini_cart'); ?>
                 ?>
               <?php else : ?>
                 <strong><a href="<?php echo esc_url($product_permalink); ?>">
-                    <?php echo $product_name; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
-                    ?>
-                  </a></strong>
+                  <?php echo $product_name; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
+                  ?>
+                </a></strong>
               <?php endif; ?>
               <div class="item-quantity">
                 <?php echo wc_get_formatted_cart_item_data($cart_item); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 


### PR DESCRIPTION
This PR removes `border-bottom p-3` classes and uses `list-group list-group-flush` component for offcanvas cart-items instead.

There is also a small improvement with the height of `cart-list`. If there are many products in the cart, the scrollbars will not cover `cart-footer` anymore.

Preview https://dev.bootscore.me/shop/

@justinkruit If you agree, I'm happy when you just hit the merge button.