### PR TITLE
Fix coupon input in cart page

### DIFF
--- a/scss/bootscore_woocommerce/_wc_cart.scss
+++ b/scss/bootscore_woocommerce/_wc_cart.scss
@@ -17,10 +17,18 @@ WooCommerce Cart
   width: 100%;
 }
 
-// Update cart button
 // WooCommerce breakpoints are at 769px
 @media (max-width: 768px) {
+
+  // Update cart button
   .shop_table_responsive .actions button:not(.input-group button) {
     width: 100%;
+  }
+
+  // Coupon input in cart page
+  .woocommerce table.cart td.actions .coupon input,
+  .woocommerce-page #content table.cart td.actions .coupon input,
+  .woocommerce-page table.cart td.actions .coupon input {
+    width: 1%;
   }
 }


### PR DESCRIPTION
This PR fixes the coupon in cart page on small devices. In languages with long words, the `input-group` breaks into 2 lines because input has `width: 48%` by WooCommerce. Now this is overridden with default Bootstrap `.input-group` > `form-control` `width: 1%`.


![text372](https://user-images.githubusercontent.com/51531217/183713198-ea30480d-42a3-42a7-a83e-aee635f7e53d.png)
