### PR TITLE
Improve WC product offcanvas

### DIFF
--- a/woocommerce/js/woocommerce.js
+++ b/woocommerce/js/woocommerce.js
@@ -1,6 +1,6 @@
 jQuery(function ($) {
   // Single add to cart button
-  $('.single_add_to_cart_button:not(.product_type_variable):not(.product_type_external):not(.product_type_grouped)').attr('data-bs-toggle', 'offcanvas').attr('data-bs-target', '#offcanvas-cart');
+  $('body.archive .product-type-simple .single_add_to_cart_button, body.single-product .single_add_to_cart_button').attr('data-bs-toggle', 'offcanvas').attr('data-bs-target', '#offcanvas-cart');
   // Single add to cart button END
 
   // Add loading class to offcanvas-cart


### PR DESCRIPTION
Based on #200, now the product offcanvas only opens when adding a simple product in an archive, or when adding any product on the single page.