### PR TITLE
Remove nav-link last-child padding

### DIFF
--- a/scss/bootscore/_header.scss
+++ b/scss/bootscore/_header.scss
@@ -6,8 +6,3 @@ Header
 html {
   scroll-padding-top: 55px;
 }
-
-// Reset Bootstrap last nav-bar nav-link padding
-#nav-main .menu-item:last-child .nav-link {
-  padding-right: 0;
-}


### PR DESCRIPTION
This snippet added an edge to edge last nav-link to container if no header widget is active. I'm not sure if we should keep this or following more the Bootstrap way and delete it.