### PR TITLE
Update both standard and WC breadcrumbs to match bootstrap 5.2 syntax

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -401,23 +401,30 @@ add_post_type_support('page', 'excerpt');
 
 // Breadcrumb
 if (!function_exists('the_breadcrumb')) :
-  function the_breadcrumb() {
-    if (!is_home()) {
-      echo '<nav class="breadcrumb mb-4 mt-2 bg-light py-2 px-3 small rounded">';
-      echo '<a href="' . home_url('/') . '">' . ('<i class="fa-solid fa-house"></i>') . '</a><span class="divider">&nbsp;/&nbsp;</span>';
-      if (is_category() || is_single()) {
-        the_category(' <span class="divider">&nbsp;/&nbsp;</span> ');
-        if (is_single()) {
-          echo ' <span class="divider">&nbsp;/&nbsp;</span> ';
-          the_title();
-        }
-      } elseif (is_page()) {
-        echo the_title();
+function the_breadcrumb()
+{
+  if (!is_home()) {
+    echo '<nav aria-label="breadcrumb" class="mb-4 mt-2 py-2 px-3">';
+    echo '<ol class="breadcrumb">';
+    echo '<li class="breadcrumb-item"><a href="' . home_url() . '">' . '<i class="fa-solid fa-house"></i>' . '</a></li>';
+    // display parent category names with links
+    if (is_category() || is_single()) {
+      $cat_IDs = wp_get_post_categories(get_the_ID());
+      foreach ($cat_IDs as $cat_ID) {
+        $cat = get_category($cat_ID);
+        echo '<li class="breadcrumb-item"><a href="' . get_term_link($cat->term_id) . '">' . $cat->name . '</a></li>';
       }
-      echo '</nav>';
     }
+    // display current page name
+    if (is_page() || is_single()) {
+      echo '<li class="breadcrumb-item active" aria-current="page">' . get_the_title() . '</li>';
+    }
+    echo '</ol>';
+    echo '</nav>';
+    echo '</nav>';
   }
-  add_filter('breadcrumbs', 'breadcrumbs');
+}
+add_filter('breadcrumbs', 'breadcrumbs');
 endif;
 // Breadcrumb END
 

--- a/woocommerce/woocommerce-functions.php
+++ b/woocommerce/woocommerce-functions.php
@@ -83,11 +83,13 @@ if (!function_exists('bs_woocommerce_breadcrumbs')) :
   add_filter('woocommerce_breadcrumb_defaults', 'bs_woocommerce_breadcrumbs');
   function bs_woocommerce_breadcrumbs() {
     return array(
-      'delimiter'   => ' &nbsp;&#47;&nbsp; ',
-      'wrap_before' => '<nav class="breadcrumb mb-4 mt-2 bg-light py-2 px-3 small rounded" itemprop="breadcrumb">',
-      'wrap_after'  => '</nav>',
-      'before'      => '',
-      'after'       => '',
+      'delimiter'   => '',
+      'wrap_before' => "<nav aria-label='breadcrumb' class='mb-4 mt-2 py-2 px-3'>
+      <ol class='breadcrumb'>",
+      'wrap_after'  => '</ol>
+      </nav>',
+      'before'      => '<li class="breadcrumb-item">',
+      'after'       => '</li>',
       'home'        => _x('Home', 'breadcrumb', 'woocommerce'),
     );
   }


### PR DESCRIPTION
Breadrumbs can now be styles as per guidance on the bootstrap 5.2 docs

https://getbootstrap.com/docs/5.2/components/breadcrumb/

The divider is styled through CSS