### PR TITLE
5.2.2.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -57,7 +57,7 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
 
 == Changelog ==
 
-    = 5.2.2.0 - October 17 2022 =
+    = 5.2.2.0 - October 18 2022 =
     
         PHP
 

--- a/readme.txt
+++ b/readme.txt
@@ -57,7 +57,7 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
 
 == Changelog ==
 
-    = 5.2.2.0 - October 18 2022 =
+    = 5.2.2.0 - October 17 2022 =
     
         PHP
 

--- a/readme.txt
+++ b/readme.txt
@@ -57,10 +57,11 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
 
 == Changelog ==
 
-    = 5.2.2.0 - October 12 2022 =
+    = 5.2.2.0 - October 13 2022 =
     
         PHP
 
+        * [IMPROVEMENT] scss compile, expanded for dev #279
         * [IMPROVEMENT] Bootstrap 5.2.2 breadcrumb component #274
         * [IMPROVEMENT] Feature package.json extra categories #276
         

--- a/readme.txt
+++ b/readme.txt
@@ -57,7 +57,7 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
 
 == Changelog ==
 
-    = 5.2.2.0 - October 13 2022 =
+    = 5.2.2.0 - October 14 2022 =
     
         PHP
 

--- a/readme.txt
+++ b/readme.txt
@@ -57,7 +57,7 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
 
 == Changelog ==
 
-    = 5.2.2.0 - October 15 2022 =
+    = 5.2.2.0 - October 17 2022 =
     
         PHP
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,13 +1,13 @@
 === bootScore ===
 
-Contributors: Bastian Kreiter, Justin Kruit, Martin Holzer, Tim Groeneveld, Laurent Binder, Patrick, Gustavo Silva, TershiXia, electronicsandprogramming, charly, Alexandros Kourmoulakis, Sven Geiß, ucalegonte, Benhaim Ido
+Contributors: Bastian Kreiter, Justin Kruit, Martin Holzer, Tim Groeneveld, Laurent Binder, Patrick, Gustavo Silva, TershiXia, electronicsandprogramming, charly, Alexandros Kourmoulakis, Sven Geiß, ucalegonte, Benhaim Ido, Sean Emerson
 
 Tags: featured-images, threaded-comments, translation-ready
 
 Requires at least: 4.5
 Tested up to: 6.0.2
 Requires PHP: 5.6
-Stable tag: 5.2.1.1
+Stable tag: 5.2.2.0
 License: MIT License
 License URI: https://github.com/bootscore/bootscore/blob/main/LICENSE
 
@@ -56,6 +56,17 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
 
 
 == Changelog ==
+
+    = 5.2.2.0 - October 12 2022 =
+    
+        PHP
+
+        * [IMPROVEMENT] Bootstrap 5.2.2 breadcrumb component #274
+        * [IMPROVEMENT] Feature package.json extra categories #276
+        
+        Updates
+
+        * [UPDATE] Bootstrap 5.2.2 #275
 
     = 5.2.1.1 - September 15 2022 =
     

--- a/readme.txt
+++ b/readme.txt
@@ -57,7 +57,7 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
 
 == Changelog ==
 
-    = 5.2.2.0 - October 14 2022 =
+    = 5.2.2.0 - October 15 2022 =
     
         PHP
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://bootscore.me/
 Author: bootScore
 Author URI: https://bootscore.me
 Description: A powerful Bootstrap 5 WordPress Starter Theme with WooCommerce Support. <a href="https://bootscore.me/category/documentation/" target="_blank">Documentation</a>. This theme gives you full control whatever you do and the full freedom to design whatever you want. It comes with a wide selection of category, page, post, author and archive templates as well as sidebar, header, footer and 404 widgets. There are no customizer settings in the backend. All settings can only be made by touching the code. Some CSS, HTML, PHP and JS Skills are required to customize it.
-Version: 5.2.1.1
+Version: 5.2.2.0
 Tested up to: 6.0.2
 Requires PHP: 5.6
 License: MIT License


### PR DESCRIPTION
Surprisingly, there are no updated templates with WooCommerce 7. This PR submits only the theme version.

@justinkruit I'm happy if you just hit the merge button and as usual, there is a drafted release as well.