### PR TITLE
Add show-password to all pages in user offcanvas

### DIFF
--- a/scss/_bscore_woocommerce.scss
+++ b/scss/_bscore_woocommerce.scss
@@ -1,5 +1,5 @@
 /*!
- * bootScore WooCommerce 5.2.3.0 (https://bootscore.me/)
+ * bootScore WooCommerce 5.2.3.1 (https://bootscore.me/)
  */
 
 @import "bootscore_woocommerce/wc_alerts";
@@ -12,6 +12,7 @@
 @import "bootscore_woocommerce/wc_loader";
 @import "bootscore_woocommerce/wc_loop";
 @import "bootscore_woocommerce/wc_my_account";
+@import "bootscore_woocommerce/wc_my_account_offcanvas";
 @import "bootscore_woocommerce/wc_qty_btn";
 @import "bootscore_woocommerce/wc_offcanvas_cart";
 @import "bootscore_woocommerce/wc_prices";

--- a/scss/bootscore_woocommerce/_wc_my_account_offcanvas.scss
+++ b/scss/bootscore_woocommerce/_wc_my_account_offcanvas.scss
@@ -1,0 +1,26 @@
+/*--------------------------------------------------------------
+WooCommerce My Account Offcanvas
+--------------------------------------------------------------*/
+
+// Add show-password to non Woo pages
+#offcanvas-user {
+  .offcanvas-password.show-password-input {
+    position: absolute;
+    right: 0.7em;
+    top: 2rem;
+    cursor: pointer;
+
+    &::after {
+      font-family: WooCommerce;
+      speak: never;
+      font-weight: 400;
+      font-variant: normal;
+      text-transform: none;
+      line-height: 1;
+      -webkit-font-smoothing: antialiased;
+      margin-left: 0.618em;
+      content: "\e010";
+      text-decoration: none;
+    }
+  }
+}

--- a/woocommerce/myaccount/my-account-offcanvas.php
+++ b/woocommerce/myaccount/my-account-offcanvas.php
@@ -55,9 +55,10 @@ if (!defined('ABSPATH')) {
             <input type="text" class="woocommerce-Input woocommerce-Input--text input-text form-control" name="username" id="username_1" autocomplete="username" value="<?php echo (!empty($_POST['username'])) ? esc_attr(wp_unslash($_POST['username'])) : ''; ?>" /><?php // @codingStandardsIgnoreLine 
                                                                                                                                                                                                                                                                         ?>
           </p>
-          <p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
+          <p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide position-relative">
             <label for="password_1"><?php esc_html_e('Password', 'woocommerce'); ?>&nbsp;<span class="required">*</span></label>
             <input class="woocommerce-Input woocommerce-Input--text input-text form-control" type="password" name="password" id="password_1" autocomplete="current-password" />
+            <span class="offcanvas-password show-password-input"></span>
           </p>
 
           <?php do_action('woocommerce_login_form'); ?>
@@ -99,23 +100,22 @@ if (!defined('ABSPATH')) {
 
               <p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
                 <label for="reg_username_1"><?php esc_html_e('Username', 'woocommerce'); ?>&nbsp;<span class="required">*</span></label>
-                <input type="text" class="woocommerce-Input woocommerce-Input--text input-text form-control" name="username" id="reg_username_1" autocomplete="username" value="<?php echo (!empty($_POST['username'])) ? esc_attr(wp_unslash($_POST['username'])) : ''; ?>" /><?php // @codingStandardsIgnoreLine 
-                                                                                                                                                                                                                                                                                ?>
+                <input type="text" class="woocommerce-Input woocommerce-Input--text input-text form-control" name="username" id="reg_username_1" autocomplete="username" value="<?php echo (!empty($_POST['username'])) ? esc_attr(wp_unslash($_POST['username'])) : ''; ?>" /><?php // @codingStandardsIgnoreLine                                                                                                                                                                                                                                                               ?>
               </p>
 
             <?php endif; ?>
 
             <p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
               <label for="reg_email_1"><?php esc_html_e('Email address', 'woocommerce'); ?>&nbsp;<span class="required">*</span></label>
-              <input type="email" class="woocommerce-Input woocommerce-Input--text input-text form-control" name="email" id="reg_email_1" autocomplete="email" value="<?php echo (!empty($_POST['email'])) ? esc_attr(wp_unslash($_POST['email'])) : ''; ?>" /><?php // @codingStandardsIgnoreLine 
-                                                                                                                                                                                                                                                                ?>
+              <input type="email" class="woocommerce-Input woocommerce-Input--text input-text form-control" name="email" id="reg_email_1" autocomplete="email" value="<?php echo (!empty($_POST['email'])) ? esc_attr(wp_unslash($_POST['email'])) : ''; ?>" /><?php // @codingStandardsIgnoreLine                                                                                                                                                                                                                                                              ?>
             </p>
 
             <?php if ('no' === get_option('woocommerce_registration_generate_password')) : ?>
 
-              <p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide mb-3">
+              <p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide mb-3 position-relative">
                 <label for="reg_password_1"><?php esc_html_e('Password', 'woocommerce'); ?>&nbsp;<span class="required">*</span></label>
                 <input type="password" class="woocommerce-Input woocommerce-Input--text input-text form-control" name="password" id="reg_password_1" autocomplete="new-password" />
+                <span class="offcanvas-password show-password-input"></span>  
               </p>
 
             <?php else : ?>


### PR DESCRIPTION
This PR adds the missing show-password in user offcanvas in non WooCommerce pages. Tested and works fine, already live on https://bootscore.me/.

## Before

| non Woo pages  | Woo pages |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/51531217/210793348-46cb9491-fcf2-4525-bc1e-fed0e8f409a5.png)  | ![shop-page](https://user-images.githubusercontent.com/51531217/210793494-184fb91e-2e9c-46d0-9cbe-7b0fa2e1bcb1.png)  |

## After

| non Woo pages  | Woo pages |
| ------------- | ------------- |
| ![after](https://user-images.githubusercontent.com/51531217/210793993-892b0e48-24dc-40cf-8ae8-170e9dbb37b9.png)  | ![shop-page](https://user-images.githubusercontent.com/51531217/210793494-184fb91e-2e9c-46d0-9cbe-7b0fa2e1bcb1.png)  |


