### PR TITLE
Make use of admin bar height css var for offcanvas and modal

### DIFF
--- a/scss/bootscore/_admin_bar.scss
+++ b/scss/bootscore/_admin_bar.scss
@@ -3,58 +3,31 @@ Admin bar
 --------------------------------------------------------------*/
 
 // Mobile
-@media (max-width: 782px) {
-
-  // Fixed admin-bar
+@include media-breakpoint-down(md) {
   #wpadminbar {
     position: fixed;
   }
-
-  .logged-in.admin-bar {
-
-    // Push content down when WP admin-bar is visible
-    .fixed-top,
-    .offcanvas:not(.offcanvas-bottom),
-    .offcanvas-sm,
-    .offcanvas-md,
-    .modal-dialog {
-      top: 46px;
-    }
-
-    // Adjust modal height
-    .modal-fullscreen,
-    .modal-fullscreen-sm-down,
-    .modal-fullscreen-md-down,
-    .modal-fullscreen-lg-down,
-    .modal-fullscreen-xl-down,
-    .modal-fullscreen-xxl-down {
-      height: calc(100% - 46px);
-    }
-  }
 }
 
-// Desktop
-@media (min-width: 783px) {
-  .logged-in.admin-bar {
+.logged-in.admin-bar {
 
-    // Push content down when WP admin-bar is visible
-    .fixed-top,
-    .offcanvas:not(.offcanvas-bottom),
-    .offcanvas-lg,
-    .offcanvas-xl,
-    .offcanvas-xxl,
-    .modal-dialog {
-      top: 32px;
-    }
+  // Push content down when WP admin-bar is visible
+  .fixed-top,
+  .offcanvas:not(.offcanvas-bottom),
+  .offcanvas-lg,
+  .offcanvas-xl,
+  .offcanvas-xxl,
+  .modal-dialog {
+    top: var(--wp-admin--admin-bar--height, 32px);
+  }
 
-    // Adjust modal height
-    .modal-fullscreen,
-    .modal-fullscreen-sm-down,
-    .modal-fullscreen-md-down,
-    .modal-fullscreen-lg-down,
-    .modal-fullscreen-xl-down,
-    .modal-fullscreen-xxl-down {
-      height: calc(100% - 32px);
-    }
+  // Adjust modal height
+  .modal-fullscreen,
+  .modal-fullscreen-sm-down,
+  .modal-fullscreen-md-down,
+  .modal-fullscreen-lg-down,
+  .modal-fullscreen-xl-down,
+  .modal-fullscreen-xxl-down {
+    height: calc(100% - var(--wp-admin--admin-bar--height, 32px));
   }
 }


### PR DESCRIPTION
The title says it all. Previously it set the top with a breakpoint, but WordPress provides a css variable that automatically sets the height. The 32px is just as a failsafe.