### PR TITLE
Add more control over scss compiler

### DIFF
--- a/inc/scss-compiler.php
+++ b/inc/scss-compiler.php
@@ -14,6 +14,12 @@ use ScssPhp\ScssPhp\Compiler;
  * Compiles the scss to a css file to be read by the browser.
  */
 function bootscore_compile_scss() {
+  $disable_compiler = apply_filters('bootscore_scss_disable_compiler', (defined('BOOTSCORE_SCSS_DISABLE_COMPILER') && BOOTSCORE_SCSS_DISABLE_COMPILER));
+
+  if ($disable_compiler) {
+    return;
+  }
+
   $compiler = new Compiler();
 
   if (bootscore_child_has_scss() && is_child_theme()) {
@@ -34,6 +40,7 @@ function bootscore_compile_scss() {
   $stored_modified = get_theme_mod('bootscore_scss_modified_timestamp', 0);
 
   $is_environment_dev = in_array(wp_get_environment_type(), array('development','local'), true);
+  $skip_environment_check = apply_filters('bootscore_scss_skip_environment_check', (defined('BOOTSCORE_SCSS_SKIP_ENVIRONMENT_CHECK') && BOOTSCORE_SCSS_SKIP_ENVIRONMENT_CHECK));
 
   if ($is_environment_dev) {
     $compiler->setSourceMap(Compiler::SOURCE_MAP_FILE);
@@ -48,7 +55,7 @@ function bootscore_compile_scss() {
   }
 
   try {
-    if ($last_modified > $stored_modified || !file_exists($css_file) || $is_environment_dev) {
+    if ($last_modified > $stored_modified || !file_exists($css_file) || $is_environment_dev && !$skip_environment_check) {
       $compiled = $compiler->compileString(file_get_contents($scss_file));
 
       if (!file_exists(dirname($css_file))) {

--- a/inc/scss-compiler.php
+++ b/inc/scss-compiler.php
@@ -29,24 +29,24 @@ function bootscore_compile_scss() {
   }
 
   $scss_file = $theme_directory . '/scss/main.scss';
-  $css_file = $theme_directory . '/css/main.css';
+  $css_file  = $theme_directory . '/css/main.css';
 
   $compiler->setImportPaths(dirname($scss_file));
   if (is_child_theme() && bootscore_child_has_scss()) {
     $compiler->addImportPath(get_template_directory() . '/scss/');
   }
 
-  $last_modified = bootscore_get_last_modified_scss($theme_directory);
+  $last_modified   = bootscore_get_last_modified_scss($theme_directory);
   $stored_modified = get_theme_mod('bootscore_scss_modified_timestamp', 0);
 
-  $is_environment_dev = in_array(wp_get_environment_type(), array('development','local'), true);
+  $is_environment_dev     = in_array(wp_get_environment_type(), array('development', 'local'), true);
   $skip_environment_check = apply_filters('bootscore_scss_skip_environment_check', (defined('BOOTSCORE_SCSS_SKIP_ENVIRONMENT_CHECK') && BOOTSCORE_SCSS_SKIP_ENVIRONMENT_CHECK));
 
   if ($is_environment_dev) {
     $compiler->setSourceMap(Compiler::SOURCE_MAP_FILE);
     $compiler->setSourceMapOptions([
-      'sourceMapURL'      => site_url('', 'relative') . '/' . substr(str_replace(ABSPATH, '', $css_file), 0, -3) . 'map',
-      'sourceMapBasepath' => substr(str_replace('\\', '/', ABSPATH), 0, -1),
+      'sourceMapURL'      => site_url('', 'relative') . '/' . substr(str_replace(ABSPATH, '', $css_file), 0, - 3) . 'map',
+      'sourceMapBasepath' => substr(str_replace('\\', '/', ABSPATH), 0, - 1),
       'sourceRoot'        => site_url('', 'relative') . '/',
     ]);
     $compiler->setOutputStyle(\ScssPhp\ScssPhp\OutputStyle::EXPANDED);
@@ -64,7 +64,7 @@ function bootscore_compile_scss() {
 
       file_put_contents($css_file, $compiled->getCss());
       if ($is_environment_dev) {
-        file_put_contents(substr($css_file, 0, -3) . 'map', $compiled->getSourceMap());
+        file_put_contents(substr($css_file, 0, - 3) . 'map', $compiled->getSourceMap());
       }
 
       set_theme_mod('bootscore_scss_modified_timestamp', $last_modified);
@@ -85,16 +85,17 @@ function bootscore_compile_scss() {
  * @return float Last modified times added together.
  */
 function bootscore_get_last_modified_scss($theme_directory) {
-  $directory = $theme_directory . '/scss/';
-  $files = scandir($directory);
+  $directory           = $theme_directory . '/scss/';
+  $files               = scandir($directory);
   $total_last_modified = 0;
   foreach ($files as $file) {
     if (strpos($file, '.scss') !== false || strpos($file, '.css') !== false) {
-      $file_stats = stat($directory . $file);
+      $file_stats          = stat($directory . $file);
       $total_last_modified += $file_stats['mtime'];
     }
   }
   $total_last_modified += stat(get_template_directory() . '/scss/bootstrap/bootstrap.scss')['mtime'];
+
   return $total_last_modified;
 }
 


### PR DESCRIPTION
This will add more control for the user over the SCSS compiler. You'll be able to disable the environment check (don't always compile in development or local) or disable the compiler completely.

**Priority of checking:**
1. If filter has been added
2. If a constant has been set
3. Fall back to `false`

Below the new filters, constants, and how to use them.

### Disabling the compiler
* Filter: `bootscore_scss_disable_compiler`
  * `add_filter('bootscore_scss_disable_compiler', '__return_true');`
* Constant: `BOOTSCORE_SCSS_DISABLE_COMPILER`
  * `define('BOOTSCORE_SCSS_DISABLE_COMPILER', true);`

### Disabling the environment check
* Filter: `bootscore_scss_skip_environment_check`
  * `add_filter('bootscore_scss_skip_environment_check', '__return_true');`
* Constant: `BOOTSCORE_SCSS_SKIP_ENVIRONMENT_CHECK`
  * `define('BOOTSCORE_SCSS_SKIP_ENVIRONMENT_CHECK', true);`

Fun additional thing:
Run the following command in the folder of the theme, and compile your styling without the need of the PHP Compiler. Note that it's formatted for Windows, and probably need to make small path changes for other platforms.
```
sass .\scss\main.scss .\css\main.css -w -I ..\bootscore-main\scss\ --no-source-map
```