### PR TITLE
Update WooCommerce 7.4.0 templates and 5.2.3.2 release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,18 +2,18 @@
 
 Contributors: Bastian Kreiter, Justin Kruit, Martin Holzer, Tim Groeneveld, Laurent Binder, Patrick, Gustavo Silva, TershiXia, 
 electronicsandprogramming, charly, Alexandros Kourmoulakis, Sven Geiß, ucalegonte, Benhaim Ido, Sean Emerson, Androidacy, Tamás Dohány,
-David Vanderhaeghe, Karsten Reincke
+David Vanderhaeghe, Karsten Reincke, Patrick Champoux
 
 Tags: featured-images, threaded-comments, translation-ready
 
 Requires at least: 4.5
 Tested up to: 6.1.1
 Requires PHP: 5.6
-Stable tag: 5.2.3.1
+Stable tag: 5.2.3.2
 License: MIT License
 License URI: https://github.com/bootscore/bootscore/blob/main/LICENSE
 
-bootScore, Bootstrap 5 WordPress Theme, Copyright 2019 - 2021 The bootScore Contributors.
+bootScore, Bootstrap 5 WordPress Theme, Copyright 2019 - 2023 The bootScore Contributors.
 
 
 === Plugin Name ===
@@ -59,6 +59,18 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
 
 == Changelog ==
 
+    = 5.2.3.2 - February 16 2023 =
+    
+        * [IMPROVEMENT] Remove WooCommerce notice templates #372
+        * [IMPROVEMENT] Remove WooCommerce btn templates #386
+        * [IMPROVEMENT] Add more control over scss compiler #375
+        * [UPDATE] screenshot.png 016bfc7
+        * [UPDATE] Fontawesome 6.3.0 #394
+        * [UPDATE] quantity-input.php (WooCommerce 7.4.0) e93256e 5a77059
+        * [UPDATE] cart.php (WooCommerce 7.4.0) ffb674c
+        * [BUGFIX] Extend compound selectors #395
+        * [BUGFIX] Remove duplicated nav closing tag in the_breadcrumb() #398
+
     = 5.2.3.1 - January 16 2023 =
     
         * [UPDATE] quantity-input.php (WooCommerce 7.2) #331
@@ -76,7 +88,6 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
         * [UPDATE] Bootstrap 5.2.3
         * [IMPROVEMENT] Türkçe
         * [NEW] Magyar, thanks to iamdtms
-
 
     = 5.2.2.1 - November 03 2022 =
     

--- a/scss/_bscore_style.scss
+++ b/scss/_bscore_style.scss
@@ -1,5 +1,5 @@
 /*!
- * bootScore 5.2.3.1 (https://bootscore.me/)
+ * bootScore 5.2.3.2 (https://bootscore.me/)
  */
 
 @import "bootscore/admin_bar";

--- a/scss/bootscore_woocommerce/_wc_qty_btn.scss
+++ b/scss/bootscore_woocommerce/_wc_qty_btn.scss
@@ -20,10 +20,4 @@ WooCommerce Quantity Input
 // Fixed width for quantity input
 .quantity {
   width: 140px;
-
-  // Disable input if product is 1 in stock or limit purchases to 1 item per order
-  // https://github.com/woocommerce/woocommerce/pull/35767
-  [max="1"] {
-    @extend :disabled;
-  }
 }

--- a/scss/bootscore_woocommerce/_wc_qty_btn.scss
+++ b/scss/bootscore_woocommerce/_wc_qty_btn.scss
@@ -21,3 +21,8 @@ WooCommerce Quantity Input
 .quantity {
   width: 140px;
 }
+
+// Disable quantity input in cart page if only 1 product is in stock
+.qty[max="1"] {
+  @extend :disabled;
+}

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://bootscore.me/
 Author: bootScore
 Author URI: https://bootscore.me
 Description: A powerful Bootstrap 5 WordPress Starter Theme with WooCommerce Support. <a href="https://bootscore.me/category/documentation/" target="_blank">Documentation</a>. This theme gives you full control whatever you do and the full freedom to design whatever you want. It comes with a wide selection of category, page, post, author and archive templates as well as sidebar, header, footer and 404 widgets. There are no customizer settings in the backend. All settings can only be made by touching the code. Some CSS, HTML, PHP and JS Skills are required to customize it.
-Version: 5.2.3.1
+Version: 5.2.3.2
 Tested up to: 6.1.1
 Requires PHP: 5.6
 License: MIT License

--- a/woocommerce/cart/cart.php
+++ b/woocommerce/cart/cart.php
@@ -13,7 +13,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.0.1
+ * @version 7.4.0
  */
 
 defined('ABSPATH') || exit;
@@ -143,7 +143,8 @@ do_action('woocommerce_before_cart'); ?>
             <div class="coupon">
               <div class="input-group">
                 <input type="text" name="coupon_code" class="form-control" id="coupon_code" value="" placeholder="<?php esc_attr_e('Coupon code', 'woocommerce'); ?>" />
-                  <button type="submit" class="input-group-text btn btn-outline-primary<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?></button>
+                <label for="coupon_code" class="screen-reader-text"><?php esc_html_e( 'Coupon:', 'woocommerce' ); ?></label> 
+                <button type="submit" class="input-group-text btn btn-outline-primary<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?></button>
                 <?php do_action('woocommerce_cart_coupon'); ?>
               </div>
             </div>

--- a/woocommerce/global/quantity-input.php
+++ b/woocommerce/global/quantity-input.php
@@ -12,7 +12,10 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.2.1
+ * @version 7.4.0
+ *
+ * @var bool   $readonly If the input should be set to readonly mode.
+ * @var string $type     The input type attribute.
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -20,13 +23,6 @@ defined( 'ABSPATH' ) || exit;
 /* translators: %s: Quantity. */
 $label = ! empty( $args['product_name'] ) ? sprintf( esc_html__( '%s quantity', 'woocommerce' ), wp_strip_all_tags( $args['product_name'] ) ) : esc_html__( 'Quantity', 'woocommerce' );
 
-// In some cases we wish to display the quantity but not allow for it to be changed.
-if ( $max_value && $min_value === $max_value ) {
-  $is_readonly = true;
-  $input_value = $min_value;
-} else {
-  $is_readonly = false;
-}
 ?>
 <div class="quantity input-group">
   <?php
@@ -39,9 +35,9 @@ if ( $max_value && $min_value === $max_value ) {
   ?>
   <button type="button" class="input-group-text qty_button minus">-</button>
   <label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_attr( $label ); ?></label>
-  <input
-    type="<?php echo $is_readonly ? 'text' : 'number'; ?>"
-    <?php echo $is_readonly ? 'readonly="readonly"' : ''; ?>
+  <input  
+    type="<?php echo esc_attr( $type ); ?>"
+ 	<?php echo $readonly ? 'readonly="readonly"' : ''; ?>
     id="<?php echo esc_attr( $input_id ); ?>"
     class="input-text qty text form-control <?php echo esc_attr( join( ' ', (array) $classes ) ); ?>"
     name="<?php echo esc_attr( $input_name ); ?>"
@@ -50,7 +46,7 @@ if ( $max_value && $min_value === $max_value ) {
     size="4"
     min="<?php echo esc_attr( $min_value ); ?>"
     max="<?php echo esc_attr( 0 < $max_value ? $max_value : '' ); ?>"
-    <?php if ( ! $is_readonly ): ?>
+    <?php if ( ! $readonly ): ?>
       step="<?php echo esc_attr( $step ); ?>"
       placeholder="<?php echo esc_attr( $placeholder ); ?>"
       inputmode="<?php echo esc_attr( $inputmode ); ?>"

--- a/woocommerce/js/woocommerce.js
+++ b/woocommerce/js/woocommerce.js
@@ -73,6 +73,9 @@ jQuery(function ($) {
     // Trigger change event
     $qty.trigger('change');
   });
+  
+  // Hide quantity input in product page if product is sold individually or only 1 in stock
+  $('.qty[type=hidden]').closest('.quantity').remove();
   // WC Quantity Input End 
   
 }); // jQuery End


### PR DESCRIPTION
This PR ships two updated Woo 7.4.0 templates and updates the version.

https://developer.woocommerce.com/2023/02/14/woocommerce-7-4-released/

About the `quantity-input.php`: There is no longer a CSS selector if only 1 product is in stock, but if product is sold individually there is. I roughly removed the input there with `$('.qty[type=hidden]').closest('.quantity').remove();` to handle both in the same way. Not beauty, but works for now. I'm pretty sure WooCommerce will update this file in next releases again.   

Tested, works fine and is already live on bootscore.me. There is already a drafted release. @justinkruit if you agree, I'm happy when you just hit the merge button and publish release.

Edit: Think we can make this better.