### PR TITLE
5.2.3.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,18 +2,18 @@
 
 Contributors: Bastian Kreiter, Justin Kruit, Martin Holzer, Tim Groeneveld, Laurent Binder, Patrick, Gustavo Silva, TershiXia, 
 electronicsandprogramming, charly, Alexandros Kourmoulakis, Sven Geiß, ucalegonte, Benhaim Ido, Sean Emerson, Androidacy, Tamás Dohány,
-David Vanderhaeghe, Karsten Reincke
+David Vanderhaeghe, Karsten Reincke, Patrick Champoux
 
 Tags: featured-images, threaded-comments, translation-ready
 
 Requires at least: 4.5
 Tested up to: 6.1.1
 Requires PHP: 5.6
-Stable tag: 5.2.3.1
+Stable tag: 5.2.3.2
 License: MIT License
 License URI: https://github.com/bootscore/bootscore/blob/main/LICENSE
 
-bootScore, Bootstrap 5 WordPress Theme, Copyright 2019 - 2021 The bootScore Contributors.
+bootScore, Bootstrap 5 WordPress Theme, Copyright 2019 - 2023 The bootScore Contributors.
 
 
 === Plugin Name ===
@@ -59,6 +59,19 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
 
 == Changelog ==
 
+    = 5.2.3.2 - February 17 2023 =
+    
+        * [IMPROVEMENT] Remove WooCommerce notice templates #372
+        * [IMPROVEMENT] Remove WooCommerce btn templates #386
+        * [IMPROVEMENT] Add more control over scss compiler #375
+        * [IMPROVEMENT] Offcanvas cart notices b2a822b, 3872704, eccb9af
+        * [UPDATE] screenshot.png 016bfc7
+        * [UPDATE] Fontawesome 6.3.0 #394
+        * [UPDATE] quantity-input.php (WooCommerce 7.4.0) 15f84aa
+        * [UPDATE] cart.php (WooCommerce 7.4.0) 6f3fa58
+        * [BUGFIX] Extend compound selectors #395
+        * [BUGFIX] Remove duplicated nav closing tag in the_breadcrumb() #398
+
     = 5.2.3.1 - January 16 2023 =
     
         * [UPDATE] quantity-input.php (WooCommerce 7.2) #331
@@ -76,7 +89,6 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
         * [UPDATE] Bootstrap 5.2.3
         * [IMPROVEMENT] Türkçe
         * [NEW] Magyar, thanks to iamdtms
-
 
     = 5.2.2.1 - November 03 2022 =
     
@@ -499,5 +511,4 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
     = 5.0.0.0 - January 29 2021 =
     
         * Initial release
-
 

--- a/readme.txt
+++ b/readme.txt
@@ -59,7 +59,7 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
 
 == Changelog ==
 
-    = 5.2.3.2 - February 17 2023 =
+    = 5.2.3.2 - February 16 2023 =
     
         * [IMPROVEMENT] Remove WooCommerce notice templates #372
         * [IMPROVEMENT] Remove WooCommerce btn templates #386

--- a/readme.txt
+++ b/readme.txt
@@ -59,7 +59,7 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
 
 == Changelog ==
 
-    = 5.2.3.2 - February 16 2023 =
+    = 5.2.3.2 - February 17 2023 =
     
         * [IMPROVEMENT] Remove WooCommerce notice templates #372
         * [IMPROVEMENT] Remove WooCommerce btn templates #386

--- a/readme.txt
+++ b/readme.txt
@@ -70,7 +70,7 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
         * [UPDATE] quantity-input.php (WooCommerce 7.4.0) 15f84aa
         * [UPDATE] cart.php (WooCommerce 7.4.0) 6f3fa58
         * [BUGFIX] Extend compound selectors #395
-        * [BUGFIX] Remove duplicated nav closing tag in the_breadcrumb() #398
+        * [BUGFIX] Remove duplicated nav closing tag in the_breadcrumb #398
 
     = 5.2.3.1 - January 16 2023 =
     

--- a/scss/_bscore_style.scss
+++ b/scss/_bscore_style.scss
@@ -1,5 +1,5 @@
 /*!
- * bootScore 5.2.3.1 (https://bootscore.me/)
+ * bootScore 5.2.3.2 (https://bootscore.me/)
  */
 
 @import "bootscore/admin_bar";

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://bootscore.me/
 Author: bootScore
 Author URI: https://bootscore.me
 Description: A powerful Bootstrap 5 WordPress Starter Theme with WooCommerce Support. <a href="https://bootscore.me/category/documentation/" target="_blank">Documentation</a>. This theme gives you full control whatever you do and the full freedom to design whatever you want. It comes with a wide selection of category, page, post, author and archive templates as well as sidebar, header, footer and 404 widgets. There are no customizer settings in the backend. All settings can only be made by touching the code. Some CSS, HTML, PHP and JS Skills are required to customize it.
-Version: 5.2.3.1
+Version: 5.2.3.2
 Tested up to: 6.1.1
 Requires PHP: 5.6
 License: MIT License


### PR DESCRIPTION
- WooCommerce 7.4 templates has been updated already here https://github.com/bootscore/bootscore/pull/401
- Tested, works fine and is already live on bootscore.me. 

There is already a drafted release. @justinkruit if you agree, I'm happy when you just hit the merge button and publish release.