### PR TITLE
Use masks instead of FA font

### DIFF
--- a/scss/bootscore/_alerts.scss
+++ b/scss/bootscore/_alerts.scss
@@ -11,29 +11,41 @@ Alerts
   }
 
   &::before {
-    font: var(--fa-font-solid);
     position: absolute;
     left: 1.25rem;
     top: 50%;
     transform: translate(0, -50%);
+    content: ' ';
+
+    mask-position: center;
+    mask-repeat: no-repeat;
+    mask-size: 16px;
+    mask-image: var(--alert-icon);
+    -webkit-mask-position: center;
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-size: 16px;
+    -webkit-mask-image: var(--alert-icon);
+    width: 16px;
+    height: 16px;
+    background-color: var(--bs-alert-color);
   }
 }
 
 // Add icons
 .alert-danger::before {
-  content: "\f071";
+  --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7 .2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8 .2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24V296c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224a32 32 0 1 0 -64 0 32 32 0 1 0 64 0z'/%3E%3C/svg%3E");
 }
 
 .alert-warning::before {
-  content: "\f06a";
+  --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z'/%3E%3C/svg%3E");
 }
 
 .alert-info::before {
-  content: "\f05a";
+  --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z'/%3E%3C/svg%3E");
 }
 
 .alert-success::before {
-  content: "\f058";
+  --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z'/%3E%3C/svg%3E");
 }
 
 // Reset link colors


### PR DESCRIPTION
This is still a concept, but already works great. This is an idea I discussed with @crftwrk before to replace the use of the Font Awesome font directly and make use of SVGs. This is because some people use the JS version of Font Awesome (like myself) which doesn't include the fonts anymore. Unfortunately using SVGs directly isn't easy as you can't change the color unless you want to add a fill to the url of the svg (making it less dynamic). Using masks we can get the same result.

The `-webkit` is needed unfortunately, as it is supported by Chrome but needs the `-webkit` for it to read it. More info: https://caniuse.com/css-masks