### PR TITLE
Use WC strings instead of bootScore in mini cart

### DIFF
--- a/woocommerce/ajax-cart/ajax-add-to-cart.php
+++ b/woocommerce/ajax-cart/ajax-add-to-cart.php
@@ -136,7 +136,7 @@ function bootscore_product_page_ajax_add_to_cart_js() {
 
               let notice = '';
               if (response.error == true) {
-                let message = `<?= sprintf( __( 'You cannot add another "%s" to your cart.', 'woocommerce' ), '“{{product_title}}”' ) ?>`;
+                let message = `<?= sprintf( __( 'You cannot add another "%s" to your cart.', 'woocommerce' ), '{{product_title}}' ) ?>`;
                 notice = `<div class="woocommerce-error">${message.replace('{{product_title}}', prod_title)}</div>`;
               } else {
                 let message = `<?= sprintf( _n( '%s has been added to your cart.', '%s have been added to your cart.', 1, 'woocommerce' ), '“{{product_title}}”' ) ?>`;

--- a/woocommerce/ajax-cart/ajax-add-to-cart.php
+++ b/woocommerce/ajax-cart/ajax-add-to-cart.php
@@ -137,7 +137,7 @@ function bootscore_product_page_ajax_add_to_cart_js() {
               let notice = '';
               if (response.error == true) {
                 let message = `<?= sprintf( __( 'You cannot add another "%s" to your cart.', 'woocommerce' ), '“{{product_title}}”' ) ?>`;
-                notice = `<div class="woocommerce-message">${message.replace('{{product_title}}', prod_title)}</div>`;
+                notice = `<div class="woocommerce-error">${message.replace('{{product_title}}', prod_title)}</div>`;
               } else {
                 let message = `<?= sprintf( _n( '%s has been added to your cart.', '%s have been added to your cart.', 1, 'woocommerce' ), '“{{product_title}}”' ) ?>`;
                 notice = `<div class="woocommerce-message">${message.replace('{{product_title}}', prod_title)}</div>`;

--- a/woocommerce/ajax-cart/ajax-add-to-cart.php
+++ b/woocommerce/ajax-cart/ajax-add-to-cart.php
@@ -136,9 +136,13 @@ function bootscore_product_page_ajax_add_to_cart_js() {
 
               let notice = '';
               if (response.error == true) {
-                notice = `<div class='woocommerce-error'><?php _e('You cannot add another', 'bootscore'); ?> “${prod_title}” <?php _e('to your cart.', 'bootscore'); ?></div>`;
+                //notice = `<div class='woocommerce-error'><?php //_e('You cannot add another', 'bootscore'); ?>// “${prod_title}” <?php //_e('to your cart.', 'bootscore'); ?>//</div>`;
+                let message = bootscore_wc.add_to_cart_error_msg;
+                notice = `<div class="woocommerce-message">${message.replace('{{product_title}}', prod_title)}</div>`;
               } else {
-                notice = `<div class="woocommerce-message">“${prod_title}” <?php _e('has been added to your cart.', 'bootscore'); ?></div>`;
+                //notice = `<div class="woocommerce-message">“${prod_title}” <?php //_e('has been added to your cart.', 'bootscore'); ?>//</div>`;
+                let message = bootscore_wc.add_to_cart_success_msg;
+                notice = `<div class="woocommerce-message">${message.replace('{{product_title}}', prod_title)}</div>`;
               }
 
               // Add new notices to offcanvas

--- a/woocommerce/ajax-cart/ajax-add-to-cart.php
+++ b/woocommerce/ajax-cart/ajax-add-to-cart.php
@@ -137,11 +137,11 @@ function bootscore_product_page_ajax_add_to_cart_js() {
               let notice = '';
               if (response.error == true) {
                 //notice = `<div class='woocommerce-error'><?php //_e('You cannot add another', 'bootscore'); ?>// “${prod_title}” <?php //_e('to your cart.', 'bootscore'); ?>//</div>`;
-                let message = bootscore_wc.add_to_cart_error_msg;
+                let message = `<?= sprintf( __( 'You cannot add another "%s" to your cart.', 'woocommerce' ), '“{{product_title}}”' ) ?>`;
                 notice = `<div class="woocommerce-message">${message.replace('{{product_title}}', prod_title)}</div>`;
               } else {
                 //notice = `<div class="woocommerce-message">“${prod_title}” <?php //_e('has been added to your cart.', 'bootscore'); ?>//</div>`;
-                let message = bootscore_wc.add_to_cart_success_msg;
+                let message = `<?= sprintf( _n( '%s has been added to your cart.', '%s have been added to your cart.', 1, 'woocommerce' ), '“{{product_title}}”' ) ?>`;
                 notice = `<div class="woocommerce-message">${message.replace('{{product_title}}', prod_title)}</div>`;
               }
 

--- a/woocommerce/ajax-cart/ajax-add-to-cart.php
+++ b/woocommerce/ajax-cart/ajax-add-to-cart.php
@@ -136,11 +136,9 @@ function bootscore_product_page_ajax_add_to_cart_js() {
 
               let notice = '';
               if (response.error == true) {
-                //notice = `<div class='woocommerce-error'><?php //_e('You cannot add another', 'bootscore'); ?>// “${prod_title}” <?php //_e('to your cart.', 'bootscore'); ?>//</div>`;
                 let message = `<?= sprintf( __( 'You cannot add another "%s" to your cart.', 'woocommerce' ), '“{{product_title}}”' ) ?>`;
                 notice = `<div class="woocommerce-message">${message.replace('{{product_title}}', prod_title)}</div>`;
               } else {
-                //notice = `<div class="woocommerce-message">“${prod_title}” <?php //_e('has been added to your cart.', 'bootscore'); ?>//</div>`;
                 let message = `<?= sprintf( _n( '%s has been added to your cart.', '%s have been added to your cart.', 1, 'woocommerce' ), '“{{product_title}}”' ) ?>`;
                 notice = `<div class="woocommerce-message">${message.replace('{{product_title}}', prod_title)}</div>`;
               }

--- a/woocommerce/woocommerce-functions.php
+++ b/woocommerce/woocommerce-functions.php
@@ -46,6 +46,10 @@ function wc_scripts() {
 
   // WooCommerce JS
   wp_enqueue_script('woocommerce-script', get_template_directory_uri() . '/woocommerce/js/woocommerce.js', array(), $modificated_WooCommerceJS, true);
+  wp_localize_script('woocommerce-script', 'bootscore_wc', array(
+    'add_to_cart_success_msg' => sprintf( _n( '%s has been added to your cart.', '%s have been added to your cart.', 1, 'woocommerce' ), '“{{product_title}}”' ),
+    'add_to_cart_error_msg' => sprintf( __( 'You cannot add another "%s" to your cart.', 'woocommerce' ), '“{{product_title}}”' ),
+  ));
 
   if (is_singular() && comments_open() && get_option('thread_comments')) {
     wp_enqueue_script('comment-reply');

--- a/woocommerce/woocommerce-functions.php
+++ b/woocommerce/woocommerce-functions.php
@@ -46,10 +46,6 @@ function wc_scripts() {
 
   // WooCommerce JS
   wp_enqueue_script('woocommerce-script', get_template_directory_uri() . '/woocommerce/js/woocommerce.js', array(), $modificated_WooCommerceJS, true);
-  wp_localize_script('woocommerce-script', 'bootscore_wc', array(
-    'add_to_cart_success_msg' => sprintf( _n( '%s has been added to your cart.', '%s have been added to your cart.', 1, 'woocommerce' ), '“{{product_title}}”' ),
-    'add_to_cart_error_msg' => sprintf( __( 'You cannot add another "%s" to your cart.', 'woocommerce' ), '“{{product_title}}”' ),
-  ));
 
   if (is_singular() && comments_open() && get_option('thread_comments')) {
     wp_enqueue_script('comment-reply');


### PR DESCRIPTION
Make it so some of the translations are being loaded from Woocommerce. Saves us making translations.