### PR TITLE
Fix searchform collapse behaviour

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -18,9 +18,11 @@ jQuery(function ($) {
     $('.top-nav-search input:first-of-type').trigger('focus');
   });
 
-  // Close collapse if searchform loses focus
-  $('.top-nav-search input:first-of-type').on('focusout', function () {
-    $('#collapse-search').collapse('hide');
+  // Close collapse if click outside searchform
+  $(document).on('click', function (event) {
+    if ($(event.target).closest('#collapse-search').length === 0) {
+      $('#collapse-search').collapse('hide');
+    }
   });
 
   // Scroll to top Button


### PR DESCRIPTION
This PR improves/fixes the searchform collapse behaviour.

### Before

https://bootscore.me

- Click on search toggler opens collapse and focusses the searchform
- If searchform loses focos, collapse hide

This works fine if bootScore/Woo searchorm or a a completely different widget is used in this position. In https://github.com/bootscore/bootscore/issues/312, a third party searchform is used. The result: On toggler click, searchform collapse opens but form gets **not** focussed. Because there is no focus, collapse close by itself.

### After

Closing collapse is now decoupled from searchform focus. Snippet checks if a click is outside `#collapse-search`and closes collapse then.

- Click on search toggler opens collapse and focusses the searchform
- If click is outside `#collapse-search`, collapse hide

#### Test

https://dev.bootscore.me/

- Click search-toggler in the navbar
- Click inside `#collapse-search` just 1px left or right next to the search´form - searchform stays open
- Click somewhere outside - collapse hides

Closes https://github.com/bootscore/bootscore/issues/312