### PR TITLE
Switch from medium featured images to an own bootScore size

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -35,7 +35,7 @@ get_header();
                 <div class="row">
                   <!-- Featured Image-->
                   <?php if (has_post_thumbnail())
-                    echo '<div class="card-img-left-md col-lg-5">' . get_the_post_thumbnail(null, 'medium') . '</div>';
+                    echo '<div class="card-img-left-md col-lg-5">' . get_the_post_thumbnail(null, 'bsTeaser') . '</div>';
                   ?>
                   <div class="col">
                     <div class="card-body">

--- a/functions.php
+++ b/functions.php
@@ -497,3 +497,8 @@ add_filter('gutenberg_use_widgets_block_editor', '__return_false');
 // Disables the block editor from managing widgets.
 add_filter('use_widgets_block_editor', '__return_false');
 // Disable Gutenberg blocks in widgets (WordPress 5.8) END
+
+// let WordPress automatically created a 'thumbnail' 600x600
+// if a picture is uploaded to the media library
+// Make that size accessible under the name 'bsTeaser'
+add_image_size( 'bsTeaser', 600, 600, true );

--- a/index.php
+++ b/index.php
@@ -47,7 +47,7 @@ get_header();
                     <div class="row">
                       <!-- Featured Image-->
                       <?php if (has_post_thumbnail())
-                        echo '<div class="card-img-left col-md-6 col-lg-4">' . get_the_post_thumbnail(null, 'medium') . '</div>';
+                        echo '<div class="card-img-left col-md-6 col-lg-4">' . get_the_post_thumbnail(null, 'bsTeaser') . '</div>';
                       ?>
                       <div class="col">
                         <div class="card-body">
@@ -110,7 +110,7 @@ get_header();
                 <div class="row">
                   <!-- Featured Image-->
                   <?php if (has_post_thumbnail())
-                    echo '<div class="card-img-left-md col-lg-5">' . get_the_post_thumbnail(null, 'medium') . '</div>';
+                    echo '<div class="card-img-left-md col-lg-5">' . get_the_post_thumbnail(null, 'bsTeaser') . '</div>';
                   ?>
                   <div class="col">
                     <div class="card-body">


### PR DESCRIPTION
There seems to be a weakness concerning dealing with Featured Images. I've described the effect in two posts: https://fodina.de/image-d/ and https://fodina.de/image-e/. If you want to see the difference, use your desktop machine and try this

* Go to https://fodina.de/ and look at the post list. The square featured images are sharp. 
* Insert the word 'Picture' into the search box and look at that list (delivered by the unmodified archive.php). On large Screens, everything blurs.

I am going to describe the technical solution in a longer statement, posted in discussions.