### PR TITLE
Add card-header to sidebar widget-cards

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -148,10 +148,10 @@ if (!function_exists('bootscore_widgets_init')) :
       'name'          => esc_html__('Sidebar', 'bootscore'),
       'id'            => 'sidebar-1',
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
-      'before_widget' => '<section id="%1$s" class="widget %2$s card card-body mb-4 bg-light border-0">',
-      'after_widget'  => '</section>',
-      'before_title'  => '<h2 class="widget-title card-title border-bottom py-2">',
-      'after_title'   => '</h2>',
+      'before_widget' => '<section id="%1$s" class="widget %2$s card mb-4">',
+      'after_widget'  => '<div></section>',
+      'before_title'  => '<h2 class="widget-title card-header h5">',
+      'after_title'   => '</h2><div class="card-body">',
     ));
     // Sidebar End
 


### PR DESCRIPTION
This PR adds `card-header` to sidebar widget cards. 

Demo: https://dev.bootscore.me/shop/

If no widget title is defined, `card-body` will not be added. Remove card border by using silent class like search widget.
```css
#secondary .widget_product_search.card {
  border: none;
}
```

| Before  | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/51531217/226837528-231a8afd-046e-4bf3-b64c-7540d1da0579.png)  | ![after](https://user-images.githubusercontent.com/51531217/226837590-1d73e2cc-ac51-4179-979a-dcc3982625e9.png)  |


