### PR TITLE
Hide duplicate empty mini-cart message in cart page

### DIFF
--- a/scss/_bscore_woocommerce.scss
+++ b/scss/_bscore_woocommerce.scss
@@ -23,6 +23,7 @@
 @import "bootscore_woocommerce/wc_sale_badge";
 @import "bootscore_woocommerce/wc_shipping";
 @import "bootscore_woocommerce/wc_shop_page";
+@import "bootscore_woocommerce/wc_temporary";
 @import "bootscore_woocommerce/wc_tables";
 @import "bootscore_woocommerce/wc_tabs";
 @import "bootscore_woocommerce/wc_thank_you";

--- a/scss/bootscore_woocommerce/_wc_temporary.scss
+++ b/scss/bootscore_woocommerce/_wc_temporary.scss
@@ -1,0 +1,10 @@
+/*--------------------------------------------------------------
+WooCommerce Temporary
+--------------------------------------------------------------*/
+
+// Hide duplicate empty mini-cart message in cart page
+// Came with one of the last WooCommerce updates
+// https://user-images.githubusercontent.com/51531217/227728763-6bef0130-f68a-4148-9c4e-6061b49feaea.png
+.woocommerce-notices-wrapper .woocommerce-mini-cart__empty-message {
+  display: none;
+}


### PR DESCRIPTION
This PR hides the duplicate empty mini-cart message in cart page. Seems that this came with one of the last Woo updates.

![](https://user-images.githubusercontent.com/51531217/227728763-6bef0130-f68a-4148-9c4e-6061b49feaea.png)

### Test

- https://bootscore.me/shop/
- Add something to the cart and go to cart page
- Remove all products in cart page with the recycle bin. 
- `No products in the cart` mini-cart message appears here

#### Fix

- Do the same here https://dev.bootscore.me/shop/

Think we should do a release soon.