### PR TITLE
Improve comments section

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -27,7 +27,7 @@ if (post_password_required()) {
   // You can start editing here -- including this comment!
   if (have_comments()) : ?>
 
-    <h2 class="comments-title">
+    <h2 class="comments-title mb-4">
       <?php
       $comments_number = get_comments_number();
       if ('1' === $comments_number) {

--- a/inc/comment-list.php
+++ b/inc/comment-list.php
@@ -22,7 +22,7 @@ if (!function_exists('bootscore_comment')) :
 
     if ('pingback' == $comment->comment_type || 'trackback' == $comment->comment_type) : ?>
 
-      <li class="alert text-bg-info" id="comment-<?php comment_ID(); ?>" <?php comment_class('media'); ?>>
+      <li class="alert alert-info" id="comment-<?php comment_ID(); ?>" <?php comment_class('media'); ?>>
         <div class="comment-body">
           <?php _e('Pingback:', 'bootscore'); ?> <?php comment_author_link(); ?> <?php edit_comment_link(__('Edit', 'bootscore'), '<span class="edit-link">', '</span>'); ?>
         </div>

--- a/inc/comment-list.php
+++ b/inc/comment-list.php
@@ -53,7 +53,7 @@ if (!function_exists('bootscore_comment')) :
 
 
                 <?php if ('0' == $comment->comment_approved) : ?>
-                  <p class="comment-awaiting-moderation"><?php _e('Your comment is awaiting moderation.', 'bootscore'); ?></p>
+                  <p class="comment-awaiting-moderation alert alert-info"><?php _e('Your comment is awaiting moderation.', 'bootscore'); ?></p>
                 <?php endif; ?>
 
                 <?php comment_text(); ?>

--- a/inc/comment-list.php
+++ b/inc/comment-list.php
@@ -22,7 +22,7 @@ if (!function_exists('bootscore_comment')) :
 
     if ('pingback' == $comment->comment_type || 'trackback' == $comment->comment_type) : ?>
 
-      <li class="bg-danger" id="comment-<?php comment_ID(); ?>" <?php comment_class('media'); ?>>
+      <li class="alert text-bg-info" id="comment-<?php comment_ID(); ?>" <?php comment_class('media'); ?>>
         <div class="comment-body">
           <?php _e('Pingback:', 'bootscore'); ?> <?php comment_author_link(); ?> <?php edit_comment_link(__('Edit', 'bootscore'), '<span class="edit-link">', '</span>'); ?>
         </div>
@@ -31,7 +31,7 @@ if (!function_exists('bootscore_comment')) :
 
       <li id="comment-<?php comment_ID(); ?>" <?php comment_class(empty($args['has_children']) ? '' : 'parent'); ?>>
 
-        <article id="div-comment-<?php comment_ID(); ?>" class="comment-body mt-4 d-flex">
+        <article id="div-comment-<?php comment_ID(); ?>" class="comment-body mb-4 d-flex">
 
           <div class="flex-shrink-0 me-3">
             <?php if (0 != $args['avatar_size']) echo get_avatar($comment, $args['avatar_size'], '', '', array('class' => 'img-thumbnail rounded-circle')); ?>
@@ -44,7 +44,7 @@ if (!function_exists('bootscore_comment')) :
                 <div class="mt-0"><?php printf(__('%s <span class="says d-none">says:</span>', 'bootscore'), sprintf('<h3 class="h5">%s</h3>', get_comment_author_link())); ?>
                 </div>
 
-                <p class="small comment-meta text-muted">
+                <p class="small comment-meta text-secondary">
                   <time datetime="<?php comment_time('c'); ?>">
                     <?php printf(_x('%1$s at %2$s', '1: date, 2: time', 'bootscore'), get_comment_date(), get_comment_time()); ?>
                   </time>
@@ -56,9 +56,7 @@ if (!function_exists('bootscore_comment')) :
                   <p class="comment-awaiting-moderation"><?php _e('Your comment is awaiting moderation.', 'bootscore'); ?></p>
                 <?php endif; ?>
 
-                <div class="card-block">
-                  <?php comment_text(); ?>
-                </div><!-- .comment-content -->
+                <?php comment_text(); ?>
 
                 <?php comment_reply_link(
                   array_merge(
@@ -67,8 +65,8 @@ if (!function_exists('bootscore_comment')) :
                       'add_below' => 'div-comment',
                       'depth'     => $depth,
                       'max_depth' => $args['max_depth'],
-                      'before'     => '<footer class="reply comment-reply">',
-                      'after'     => '</footer><!-- .reply -->'
+                      'before'     => '<p class="reply comment-reply">',
+                      'after'     => '</p>'
                     )
                   )
                 ); ?>
@@ -89,7 +87,7 @@ endif; // ends check for bootscore_comment()
 // h2 Reply Title
 add_filter('comment_form_defaults', 'custom_reply_title');
 function custom_reply_title($defaults) {
-  $defaults['title_reply_before'] = '<h2 id="reply-title" class="mt-4">';
+  $defaults['title_reply_before'] = '<h2 id="reply-title" class="h4">';
   $defaults['title_reply_after'] = '</h2>';
   return $defaults;
 }

--- a/scss/bootscore/_comments.scss
+++ b/scss/bootscore/_comments.scss
@@ -44,7 +44,7 @@ ul.comment-list {
 }
 
 #cancel-comment-reply-link {
-  margin-left: 1rem;
+  margin-left: $spacer * .5;
 }
 
 // Adding width to comment. When using <pre> in comment, comment-content will not crashed

--- a/scss/bootscore/_comments.scss
+++ b/scss/bootscore/_comments.scss
@@ -59,3 +59,11 @@ ul.comment-list {
 .bypostauthor {
   display: block;
 }
+
+.comment-content .card p:last-child {
+  margin-bottom: 0;
+}
+
+.comment-respond {
+  margin-bottom: $spacer * 1.5;
+}

--- a/scss/bootscore/_comments.scss
+++ b/scss/bootscore/_comments.scss
@@ -60,6 +60,7 @@ ul.comment-list {
   display: block;
 }
 
+// Last p bottom margin in comment card
 .comment-content .card p:last-child {
   margin-bottom: 0;
 }

--- a/scss/bootscore_woocommerce/_wc_alerts.scss
+++ b/scss/bootscore_woocommerce/_wc_alerts.scss
@@ -18,7 +18,8 @@ WooCommerce Alerts
   @extend .alert-danger-icon;
 }
 
-.woocommerce-info {
+.woocommerce-info,
+.woocommerce-noreviews {
   @extend .alert;
   @extend .alert-info;
   @extend .alert-icon;

--- a/scss/bootscore_woocommerce/_wc_comments.scss
+++ b/scss/bootscore_woocommerce/_wc_comments.scss
@@ -12,8 +12,3 @@ WooCommerce Comments
 #woo-comments .depth-2 {
   padding-left: 65px;
 }
-
-// Last p bottom margin in comment card
-#woo-comments .comment-content p:last-child {
-  margin-bottom: 0;
-}

--- a/scss/bootscore_woocommerce/_wc_comments.scss
+++ b/scss/bootscore_woocommerce/_wc_comments.scss
@@ -12,3 +12,7 @@ WooCommerce Comments
 #woo-comments .depth-2 {
   padding-left: 65px;
 }
+
+.woocommerce #reviews h3 {
+  margin-bottom: $spacer * .5,;
+}


### PR DESCRIPTION
This PR improves the comment section by spacing utilities, some alerts and a `card-text` clone to remove bottom-margin from last `<p>` in comment cards. No breaking changes

Demo: 

- https://dev.bootscore.me/2012/01/03/template-comments/
- https://dev.bootscore.me/2012/01/01/template-pingbacks-an-trackbacks/
- https://dev.bootscore.me/product/album/#reviews
- https://dev.bootscore.me/product/beanie-with-logo/#reviews

@justinkruit if you agree, I'm happy when you just hit the merge button. 