### PR TITLE
Add 2 more widget areas and improve existing ones

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -53,7 +53,6 @@
             <?php dynamic_sidebar('footer-4'); ?>
           <?php endif; ?>
         </div>
-        <!-- Footer Widgets End -->
 
       </div>
 
@@ -78,7 +77,7 @@
       <?php if (is_active_sidebar('footer-info')) : ?>
         <?php dynamic_sidebar('footer-info'); ?>
       <?php endif; ?>
-      <small>&copy;&nbsp;<?php echo Date('Y'); ?> - <?php bloginfo('name'); ?></small>
+      <small class="bootscore-copyright">&copy;&nbsp;<?php echo Date('Y'); ?> - <?php bloginfo('name'); ?></small>
     </div>
   </div>
 

--- a/footer.php
+++ b/footer.php
@@ -73,8 +73,11 @@
     </div>
   </div>
 
-  <div class="bootscore-info bg-light text-muted border-top py-2 text-center">
+  <div class="bootscore-info bg-light text-secondary border-top py-2 text-center">
     <div class="<?php echo bootscore_container_class(); ?>">
+      <?php if (is_active_sidebar('footer-info')) : ?>
+        <?php dynamic_sidebar('footer-info'); ?>
+      <?php endif; ?>
       <small>&copy;&nbsp;<?php echo Date('Y'); ?> - <?php bloginfo('name'); ?></small>
     </div>
   </div>

--- a/footer.php
+++ b/footer.php
@@ -21,9 +21,7 @@
 
       <!-- Top Footer Widget -->
       <?php if (is_active_sidebar('top-footer')) : ?>
-        <div>
-          <?php dynamic_sidebar('top footer'); ?>
-        </div>
+        <?php dynamic_sidebar('top footer'); ?>
       <?php endif; ?>
 
       <div class="row">
@@ -31,36 +29,28 @@
         <!-- Footer 1 Widget -->
         <div class="col-md-6 col-lg-3">
           <?php if (is_active_sidebar('footer-1')) : ?>
-            <div>
-              <?php dynamic_sidebar('footer-1'); ?>
-            </div>
+            <?php dynamic_sidebar('footer-1'); ?>
           <?php endif; ?>
         </div>
 
         <!-- Footer 2 Widget -->
         <div class="col-md-6 col-lg-3">
           <?php if (is_active_sidebar('footer-2')) : ?>
-            <div>
-              <?php dynamic_sidebar('footer-2'); ?>
-            </div>
+            <?php dynamic_sidebar('footer-2'); ?>
           <?php endif; ?>
         </div>
 
         <!-- Footer 3 Widget -->
         <div class="col-md-6 col-lg-3">
           <?php if (is_active_sidebar('footer-3')) : ?>
-            <div>
-              <?php dynamic_sidebar('footer-3'); ?>
-            </div>
+            <?php dynamic_sidebar('footer-3'); ?>
           <?php endif; ?>
         </div>
 
         <!-- Footer 4 Widget -->
         <div class="col-md-6 col-lg-3">
           <?php if (is_active_sidebar('footer-4')) : ?>
-            <div>
-              <?php dynamic_sidebar('footer-4'); ?>
-            </div>
+            <?php dynamic_sidebar('footer-4'); ?>
           <?php endif; ?>
         </div>
         <!-- Footer Widgets End -->
@@ -79,7 +69,6 @@
         'walker' => new bootstrap_5_wp_nav_menu_walker()
       ));
       ?>
-      <!-- Bootstrap 5 Nav Walker Footer Menu End -->
 
     </div>
   </div>

--- a/functions.php
+++ b/functions.php
@@ -131,6 +131,7 @@ if (!function_exists('bootscore_widgets_init')) :
     ));
     
     // Top Nav 2
+    // Adds a widget next to the Top Nav position but moves to offcanvas on <lg breakpoint
     register_sidebar(array(
       'name'          => esc_html__('Top Nav 2', 'bootscore'),
       'id'            => 'top-nav-2',

--- a/functions.php
+++ b/functions.php
@@ -124,12 +124,24 @@ if (!function_exists('bootscore_widgets_init')) :
       'name'          => esc_html__('Top Nav', 'bootscore'),
       'id'            => 'top-nav',
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
-      'before_widget' => '<div class="ms-3">',
+      'before_widget' => '<div class="ms-2">',
       'after_widget'  => '</div>',
       'before_title'  => '<div class="widget-title d-none">',
       'after_title'   => '</div>'
     ));
     // Top Nav End
+    
+    // Top Nav 2
+    register_sidebar(array(
+      'name'          => esc_html__('Top Nav 2', 'bootscore'),
+      'id'            => 'top-nav-2',
+      'description'   => esc_html__('Add widgets here.', 'bootscore'),
+      'before_widget' => '<div class="mt-2 mt-lg-0 ms-lg-2">',
+      'after_widget'  => '</div>',
+      'before_title'  => '<div class="widget-title d-none">',
+      'after_title'   => '</div>'
+    ));
+    // Top Nav 2 End  
 
     // Top Nav Search
     register_sidebar(array(
@@ -174,7 +186,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
       'before_widget' => '<div class="footer_widget mb-4">',
       'after_widget'  => '</div>',
-      'before_title'  => '<h2 class="widget-title h4">',
+      'before_title'  => '<h2 class="widget-title h5">',
       'after_title'   => '</h2>'
     ));
     // Footer 1 End
@@ -186,7 +198,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
       'before_widget' => '<div class="footer_widget mb-4">',
       'after_widget'  => '</div>',
-      'before_title'  => '<h2 class="widget-title h4">',
+      'before_title'  => '<h2 class="widget-title h5">',
       'after_title'   => '</h2>'
     ));
     // Footer 2 End
@@ -198,7 +210,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
       'before_widget' => '<div class="footer_widget mb-4">',
       'after_widget'  => '</div>',
-      'before_title'  => '<h2 class="widget-title h4">',
+      'before_title'  => '<h2 class="widget-title h5">',
       'after_title'   => '</h2>'
     ));
     // Footer 3 End
@@ -210,7 +222,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
       'before_widget' => '<div class="footer_widget mb-4">',
       'after_widget'  => '</div>',
-      'before_title'  => '<h2 class="widget-title h4">',
+      'before_title'  => '<h2 class="widget-title h5">',
       'after_title'   => '</h2>'
     ));
     // Footer 4 End

--- a/functions.php
+++ b/functions.php
@@ -129,7 +129,6 @@ if (!function_exists('bootscore_widgets_init')) :
       'before_title'  => '<div class="widget-title d-none">',
       'after_title'   => '</div>'
     ));
-    // Top Nav End
     
     // Top Nav 2
     register_sidebar(array(
@@ -140,8 +139,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'after_widget'  => '</div>',
       'before_title'  => '<div class="widget-title d-none">',
       'after_title'   => '</div>'
-    ));
-    // Top Nav 2 End  
+    )); 
 
     // Top Nav Search
     register_sidebar(array(
@@ -153,7 +151,6 @@ if (!function_exists('bootscore_widgets_init')) :
       'before_title'  => '<div class="widget-title d-none">',
       'after_title'   => '</div>'
     ));
-    // Top Nav Search End
 
     // Sidebar
     register_sidebar(array(
@@ -165,7 +162,6 @@ if (!function_exists('bootscore_widgets_init')) :
       'before_title'  => '<h2 class="widget-title card-header h5">',
       'after_title'   => '</h2><div class="card-body">',
     ));
-    // Sidebar End
 
     // Top Footer
     register_sidebar(array(
@@ -177,7 +173,6 @@ if (!function_exists('bootscore_widgets_init')) :
       'before_title'  => '<h2 class="widget-title">',
       'after_title'   => '</h2>'
     ));
-    // Top Footer End
 
     // Footer 1
     register_sidebar(array(
@@ -189,7 +184,6 @@ if (!function_exists('bootscore_widgets_init')) :
       'before_title'  => '<h2 class="widget-title h5">',
       'after_title'   => '</h2>'
     ));
-    // Footer 1 End
 
     // Footer 2
     register_sidebar(array(
@@ -201,7 +195,6 @@ if (!function_exists('bootscore_widgets_init')) :
       'before_title'  => '<h2 class="widget-title h5">',
       'after_title'   => '</h2>'
     ));
-    // Footer 2 End
 
     // Footer 3
     register_sidebar(array(
@@ -213,7 +206,6 @@ if (!function_exists('bootscore_widgets_init')) :
       'before_title'  => '<h2 class="widget-title h5">',
       'after_title'   => '</h2>'
     ));
-    // Footer 3 End
 
     // Footer 4
     register_sidebar(array(
@@ -225,7 +217,17 @@ if (!function_exists('bootscore_widgets_init')) :
       'before_title'  => '<h2 class="widget-title h5">',
       'after_title'   => '</h2>'
     ));
-    // Footer 4 End
+    
+    // Footer Info
+    register_sidebar(array(
+      'name'          => esc_html__('Footer Info', 'bootscore'),
+      'id'            => 'footer-info',
+      'description'   => esc_html__('Add widgets here.', 'bootscore'),
+      'before_widget' => '<div class="footer_widget">',
+      'after_widget'  => '</div>',
+      'before_title'  => '<div class="widget-title d-none">',
+      'after_title'   => '</div>'
+    ));  
 
     // 404 Page
     register_sidebar(array(
@@ -237,11 +239,9 @@ if (!function_exists('bootscore_widgets_init')) :
       'before_title'  => '<h1 class="widget-title">',
       'after_title'   => '</h1>'
     ));
-    // 404 Page End
 
   }
   add_action('widgets_init', 'bootscore_widgets_init');
-
 
 endif;
 // Widgets END

--- a/functions.php
+++ b/functions.php
@@ -124,7 +124,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'name'          => esc_html__('Top Nav', 'bootscore'),
       'id'            => 'top-nav',
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
-      'before_widget' => '<div class="ms-2">',
+      'before_widget' => '<div class="top-nav-widget ms-2">',
       'after_widget'  => '</div>',
       'before_title'  => '<div class="widget-title d-none">',
       'after_title'   => '</div>'
@@ -136,7 +136,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'name'          => esc_html__('Top Nav 2', 'bootscore'),
       'id'            => 'top-nav-2',
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
-      'before_widget' => '<div class="mt-2 mt-lg-0 ms-lg-2">',
+      'before_widget' => '<div class="top-nav-widget-2 d-lg-flex align-items-lg-center mt-2 mt-lg-0 ms-lg-2">',
       'after_widget'  => '</div>',
       'before_title'  => '<div class="widget-title d-none">',
       'after_title'   => '</div>'

--- a/functions.php
+++ b/functions.php
@@ -161,7 +161,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'id'            => 'sidebar-1',
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
       'before_widget' => '<section id="%1$s" class="widget %2$s card mb-4">',
-      'after_widget'  => '<div></section>',
+      'after_widget'  => '</div></section>',
       'before_title'  => '<h2 class="widget-title card-header h5">',
       'after_title'   => '</h2><div class="card-body">',
     ));

--- a/functions.php
+++ b/functions.php
@@ -157,10 +157,10 @@ if (!function_exists('bootscore_widgets_init')) :
       'name'          => esc_html__('Sidebar', 'bootscore'),
       'id'            => 'sidebar-1',
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
-      'before_widget' => '<section id="%1$s" class="widget %2$s card mb-4">',
-      'after_widget'  => '</div></section>',
+      'before_widget' => '<section id="%1$s" class="widget %2$s card card-body mb-4">',
+      'after_widget'  => '</section>',
       'before_title'  => '<h2 class="widget-title card-header h5">',
-      'after_title'   => '</h2><div class="card-body">',
+      'after_title'   => '</h2>',
     ));
 
     // Top Footer

--- a/header-woocommerce.php
+++ b/header-woocommerce.php
@@ -51,11 +51,12 @@
 
             <!-- Offcanvas Navbar -->
             <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvas-navbar">
-              <div class="offcanvas-header bg-light">
-                <span class="h5 mb-0"><?php esc_html_e('Menu', 'bootscore'); ?></span>
+              <div class="offcanvas-header">
+                <span class="h5 offcanvas-title"><?php esc_html_e('Menu', 'bootscore'); ?></span>
                 <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
               </div>
               <div class="offcanvas-body">
+                
                 <!-- Bootstrap 5 Nav Walker Main Menu -->
                 <?php
                 wp_nav_menu(array(
@@ -68,7 +69,16 @@
                   'walker' => new bootstrap_5_wp_nav_menu_walker()
                 ));
                 ?>
-                <!-- Bootstrap 5 Nav Walker Main Menu End -->
+                
+                <!-- Top Nav 2 Widget -->
+                <div class="top-nav-widget-2 d-lg-flex align-items-lg-center">
+                  <?php if (is_active_sidebar('top-nav-2')) : ?>
+                    <div>
+                      <?php dynamic_sidebar('top-nav-2'); ?>
+                    </div>
+                  <?php endif; ?>
+                </div>                
+                
               </div>
             </div>
 
@@ -132,8 +142,8 @@
 
       <!-- offcanvas user -->
       <div class="offcanvas offcanvas-start" tabindex="-1" id="offcanvas-user">
-        <div class="offcanvas-header bg-light">
-          <span class="h5 mb-0"><?php esc_html_e('Account', 'bootscore'); ?></span>
+        <div class="offcanvas-header">
+          <span class="h5 offcanvas-title"><?php esc_html_e('Account', 'bootscore'); ?></span>
           <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </div>
         <div class="offcanvas-body">
@@ -145,8 +155,8 @@
 
       <!-- offcanvas cart -->
       <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvas-cart">
-        <div class="offcanvas-header bg-light">
-          <span class="h5 mb-0"><?php esc_html_e('Cart', 'bootscore'); ?></span>
+        <div class="offcanvas-header">
+          <span class="h5 offcanvas-title"><?php esc_html_e('Cart', 'bootscore'); ?></span>
           <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </div>
         <div class="offcanvas-body p-0">

--- a/header-woocommerce.php
+++ b/header-woocommerce.php
@@ -72,10 +72,8 @@
                 
                 <!-- Top Nav 2 Widget -->
                 <?php if (is_active_sidebar('top-nav-2')) : ?>
-                  <div class="top-nav-widget-2 d-lg-flex align-items-lg-center">
-                    <?php dynamic_sidebar('top-nav-2'); ?>
-                  </div>
-                <?php endif; ?>             
+                  <?php dynamic_sidebar('top-nav-2'); ?>
+                <?php endif; ?>           
                 
               </div>
             </div>
@@ -84,9 +82,7 @@
 
               <!-- Top Nav Widget -->
               <?php if (is_active_sidebar('top-nav')) : ?>
-                <div class="top-nav-widget">
-                  <?php dynamic_sidebar('top-nav'); ?>
-                </div>
+                <?php dynamic_sidebar('top-nav'); ?>
               <?php endif; ?>
 
               <!-- Search Toggler -->

--- a/header-woocommerce.php
+++ b/header-woocommerce.php
@@ -71,13 +71,11 @@
                 ?>
                 
                 <!-- Top Nav 2 Widget -->
-                <div class="top-nav-widget-2 d-lg-flex align-items-lg-center">
-                  <?php if (is_active_sidebar('top-nav-2')) : ?>
-                    <div>
-                      <?php dynamic_sidebar('top-nav-2'); ?>
-                    </div>
-                  <?php endif; ?>
-                </div>                
+                <?php if (is_active_sidebar('top-nav-2')) : ?>
+                  <div class="top-nav-widget-2 d-lg-flex align-items-lg-center">
+                    <?php dynamic_sidebar('top-nav-2'); ?>
+                  </div>
+                <?php endif; ?>             
                 
               </div>
             </div>
@@ -85,13 +83,11 @@
             <div class="header-actions d-flex align-items-center">
 
               <!-- Top Nav Widget -->
-              <div class="top-nav-widget">
-                <?php if (is_active_sidebar('top-nav')) : ?>
-                  <div>
-                    <?php dynamic_sidebar('top-nav'); ?>
-                  </div>
-                <?php endif; ?>
-              </div>
+              <?php if (is_active_sidebar('top-nav')) : ?>
+                <div class="top-nav-widget">
+                  <?php dynamic_sidebar('top-nav'); ?>
+                </div>
+              <?php endif; ?>
 
               <!-- Search Toggler -->
               <button class="btn btn-outline-secondary ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
@@ -125,18 +121,16 @@
 
             </div><!-- .header-actions -->
 
-          </div><!-- .<?php echo bootscore_container_class(); ?> -->
+          </div><!-- bootscore_container_class(); -->
 
         </nav><!-- .navbar -->
 
-        <!-- Top Nav Search Collapse -->
-        <div class="collapse <?php echo bootscore_container_class(); ?>" id="collapse-search">
-          <?php if (is_active_sidebar('top-nav-search')) : ?>
-            <div class="mb-2">
-              <?php dynamic_sidebar('top-nav-search'); ?>
-            </div>
-          <?php endif; ?>
-        </div>
+        <!-- Top Nav Search Collapse -->        
+        <?php if (is_active_sidebar('top-nav-search')) : ?>
+          <div class="collapse <?php echo bootscore_container_class(); ?> mb-2" id="collapse-search">
+            <?php dynamic_sidebar('top-nav-search'); ?>
+          </div>
+        <?php endif; ?>
 
       </div><!-- .fixed-top .bg-light -->
 

--- a/header-woocommerce.php
+++ b/header-woocommerce.php
@@ -86,9 +86,11 @@
               <?php endif; ?>
 
               <!-- Search Toggler -->
-              <button class="btn btn-outline-secondary ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
-                <i class="fa-solid fa-magnifying-glass"></i><span class="visually-hidden-focusable">Search</span>
-              </button>
+              <?php if (is_active_sidebar('top-nav-search')) : ?>
+                <button class="btn btn-outline-secondary ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
+                  <i class="fa-solid fa-magnifying-glass"></i><span class="visually-hidden-focusable">Search</span>
+                </button>
+              <?php endif; ?>
 
               <!-- User Toggler -->
               <button class="btn btn-outline-secondary ms-1 ms-md-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-user" aria-controls="offcanvas-user">

--- a/header.php
+++ b/header.php
@@ -71,28 +71,23 @@
                 ?>
                 
                 <!-- Top Nav 2 Widget -->
-                <div class="top-nav-widget-2 d-lg-flex align-items-lg-center">
-                  <?php if (is_active_sidebar('top-nav-2')) : ?>
-                    <div>
-                      <?php dynamic_sidebar('top-nav-2'); ?>
-                    </div>
-                  <?php endif; ?>
-                </div>
+                <?php if (is_active_sidebar('top-nav-2')) : ?>
+                  <div class="top-nav-widget-2 d-lg-flex align-items-lg-center">
+                    <?php dynamic_sidebar('top-nav-2'); ?>
+                  </div>
+                <?php endif; ?>
                 
               </div>
             </div>
 
-
             <div class="header-actions d-flex align-items-center">
 
               <!-- Top Nav Widget -->
-              <div class="top-nav-widget">
-                <?php if (is_active_sidebar('top-nav')) : ?>
-                  <div>
-                    <?php dynamic_sidebar('top-nav'); ?>
-                  </div>
-                <?php endif; ?>
-              </div>
+              <?php if (is_active_sidebar('top-nav')) : ?>
+                <div class="top-nav-widget">
+                  <?php dynamic_sidebar('top-nav'); ?>
+                </div>
+              <?php endif; ?>
 
               <!-- Searchform Large -->
               <div class="d-none d-lg-block ms-1 ms-md-2 top-nav-search-lg">
@@ -115,18 +110,16 @@
 
             </div><!-- .header-actions -->
 
-          </div><!-- .<?php echo bootscore_container_class(); ?> -->
+          </div><!-- bootscore_container_class(); -->
 
         </nav><!-- .navbar -->
 
         <!-- Top Nav Search Mobile Collapse -->
-        <div class="collapse <?php echo bootscore_container_class(); ?> d-lg-none" id="collapse-search">
-          <?php if (is_active_sidebar('top-nav-search')) : ?>
-            <div class="mb-2">
-              <?php dynamic_sidebar('top-nav-search'); ?>
-            </div>
-          <?php endif; ?>
-        </div>
+        <?php if (is_active_sidebar('top-nav-search')) : ?>
+          <div class="collapse <?php echo bootscore_container_class(); ?> d-lg-none mb-2" id="collapse-search">
+            <?php dynamic_sidebar('top-nav-search'); ?>
+          </div>
+        <?php endif; ?>
 
       </div><!-- .fixed-top .bg-light -->
 

--- a/header.php
+++ b/header.php
@@ -72,9 +72,7 @@
                 
                 <!-- Top Nav 2 Widget -->
                 <?php if (is_active_sidebar('top-nav-2')) : ?>
-                  <div class="top-nav-widget-2 d-lg-flex align-items-lg-center">
-                    <?php dynamic_sidebar('top-nav-2'); ?>
-                  </div>
+                  <?php dynamic_sidebar('top-nav-2'); ?>
                 <?php endif; ?>
                 
               </div>
@@ -84,19 +82,15 @@
 
               <!-- Top Nav Widget -->
               <?php if (is_active_sidebar('top-nav')) : ?>
-                <div class="top-nav-widget">
-                  <?php dynamic_sidebar('top-nav'); ?>
-                </div>
+                <?php dynamic_sidebar('top-nav'); ?>
               <?php endif; ?>
 
               <!-- Searchform Large -->
-              <div class="d-none d-lg-block ms-1 ms-md-2 top-nav-search-lg">
-                <?php if (is_active_sidebar('top-nav-search')) : ?>
-                  <div>
-                    <?php dynamic_sidebar('top-nav-search'); ?>
-                  </div>
-                <?php endif; ?>
-              </div>
+              <?php if (is_active_sidebar('top-nav-search')) : ?>
+               <div class="d-none d-lg-block ms-1 ms-md-2 top-nav-search-lg">
+                  <?php dynamic_sidebar('top-nav-search'); ?>
+                </div>
+              <?php endif; ?>
 
               <!-- Search Toggler Mobile -->
               <button class="btn btn-outline-secondary d-lg-none ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">

--- a/header.php
+++ b/header.php
@@ -93,9 +93,11 @@
               <?php endif; ?>
 
               <!-- Search Toggler Mobile -->
-              <button class="btn btn-outline-secondary d-lg-none ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
-                <i class="fa-solid fa-magnifying-glass"></i><span class="visually-hidden-focusable">Search</span>
-              </button>
+              <?php if (is_active_sidebar('top-nav-search')) : ?>
+                <button class="btn btn-outline-secondary d-lg-none ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
+                  <i class="fa-solid fa-magnifying-glass"></i><span class="visually-hidden-focusable">Search</span>
+                </button>
+              <?php endif; ?>
 
               <!-- Navbar Toggler -->
               <button class="btn btn-outline-secondary d-lg-none ms-1 ms-md-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-navbar" aria-controls="offcanvas-navbar">

--- a/header.php
+++ b/header.php
@@ -51,11 +51,12 @@
 
             <!-- Offcanvas Navbar -->
             <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvas-navbar">
-              <div class="offcanvas-header bg-light">
-                <span class="h5 mb-0"><?php esc_html_e('Menu', 'bootscore'); ?></span>
+              <div class="offcanvas-header">
+                <span class="h5 offcanvas-title"><?php esc_html_e('Menu', 'bootscore'); ?></span>
                 <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
               </div>
               <div class="offcanvas-body">
+                
                 <!-- Bootstrap 5 Nav Walker Main Menu -->
                 <?php
                 wp_nav_menu(array(
@@ -68,7 +69,16 @@
                   'walker' => new bootstrap_5_wp_nav_menu_walker()
                 ));
                 ?>
-                <!-- Bootstrap 5 Nav Walker Main Menu End -->
+                
+                <!-- Top Nav 2 Widget -->
+                <div class="top-nav-widget-2 d-lg-flex align-items-lg-center">
+                  <?php if (is_active_sidebar('top-nav-2')) : ?>
+                    <div>
+                      <?php dynamic_sidebar('top-nav-2'); ?>
+                    </div>
+                  <?php endif; ?>
+                </div>
+                
               </div>
             </div>
 

--- a/js/theme.js
+++ b/js/theme.js
@@ -9,6 +9,8 @@ jQuery(function ($) {
   });
 
   // Search collapse button hide if empty
+  // Deprecated v5.3, done by php if (is_active_sidebar('top-nav-search')) in header.php
+  // Remove in v6
   if ($('#collapse-search').children().length == 0) {
     $('.top-nav-search-md, .top-nav-search-lg').remove();
   }

--- a/scss/bootscore/_widgets.scss
+++ b/scss/bootscore/_widgets.scss
@@ -2,6 +2,15 @@
 Widgets
 --------------------------------------------------------------*/
 
+// Use negative margins for card-header which is inside the card-body in sidebar-widgets
+// See https://github.com/bootscore/bootscore/issues/444
+#secondary .card-header {
+  margin-top: calc(-1 * var(--#{$prefix}card-spacer-y));
+  margin-right: calc(-1 * var(--#{$prefix}card-spacer-x));
+  margin-bottom: var(--#{$prefix}card-spacer-x);
+  margin-left: calc(-1 * var(--#{$prefix}card-spacer-x));
+}
+
 // Reset ul in sidebar and footer widgets
 .widget-area ul,
 .bootscore-footer ul {

--- a/sidebar.php
+++ b/sidebar.php
@@ -22,7 +22,7 @@ if (!is_active_sidebar('sidebar-1')) {
     </button>
 
     <div class="offcanvas-md offcanvas-end" tabindex="-1" id="sidebar" aria-labelledby="sidebarLabel">
-      <div class="offcanvas-header bg-light">
+      <div class="offcanvas-header">
         <span class="h5 offcanvas-title" id="sidebarLabel"><?php esc_html_e('Sidebar', 'bootscore'); ?></span>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" data-bs-target="#sidebar" aria-label="Close"></button>
       </div>


### PR DESCRIPTION
This PR registers 2 new widgets and fixes existing issues. No breaking changes.

Demo: https://dev.bootscore.me/

Closes https://github.com/bootscore/bootscore/issues/444

![01](https://user-images.githubusercontent.com/51531217/232004289-1eed76ab-04e3-4f63-b000-8eec10a8daf7.png)



| Mobile  | Mobile |
| ------------- | ------------- |
| ![mobile](https://user-images.githubusercontent.com/51531217/232004488-7a99e14c-c9a5-4aa0-8b95-be595ddce6c6.png) | ![top-nav-2](https://user-images.githubusercontent.com/51531217/232004597-4f1bf3b0-cc9f-490d-9c8c-37df0729308c.png) |

### header.php

- New `Top Nav 2` widget. While the existing `Top Nav` widget stays in navbar on `<lg` screen, `Top Nav 2` moves to offcanvas. Very usefull if you want to move for example the search widget to offcanvas on mobile.
- General clean-up and reorder widgets HTML. No empty `<div>`'s anymore if widget is not active. Uses `<?php if (is_active_sidebar('top-nav-search')) : ?>` instead jQuery to hide search toggler if search widget is not active. jQuery fallback snippet is still there.
- Removed `bg-light` from `offcanvas-header` and added `offcanvas-title` (Bootstrap examples)

### Sidebar

- In https://github.com/bootscore/bootscore/pull/431, `card-header` is not created if widget has no title.
- `card-header` is now inside `card-body` and negative margins used to get `card-header` back in place. Not beauty, but works. `card-body` is now always created, no matter if a sidebar widget has a title or not. 


### footer.php

- New `Footer Info` widget. Allows to add additional information next to the copyright. Copyright has now a class and can simply removed by CSS https://github.com/orgs/bootscore/discussions/389.
- General clean-up and reorder widgets HTML
- Changed footer heading class from `h4` to `h5` (Bootstrap examples)




@justinkruit if you like it, merge it.