### PR TITLE
Make main col width dynamic

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -17,7 +17,7 @@ get_header();
     <?php bs_after_primary(); ?>
 
     <div class="row">
-      <div class="col">
+      <div class="<?php echo bootscore_main_col_class(); ?>">
 
         <main id="main" class="site-main">
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -55,7 +55,7 @@ if ( !function_exists( 'bootscore_container_class' ) ) {
  * @return string
  */
 if ( !function_exists( 'bootscore_main_col_class' ) ) {
-  function bootscore_col_main_class() {
+  function bootscore_main_col_class() {
     if (!is_active_sidebar('sidebar-1')) {
       // Sidebar is empty
       return "col";

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -27,6 +27,7 @@ function bootscore_body_classes($classes) {
 }
 add_filter('body_class', 'bootscore_body_classes');
 
+
 /**
  * Add a pingback url auto-discovery header for single posts, pages, or attachments.
  */
@@ -43,7 +44,24 @@ add_action('wp_head', 'bootscore_pingback_header');
  * @return string
  */
 if ( !function_exists( 'bootscore_container_class' ) ) {
-	function bootscore_container_class() {
-		return "container";
-	}
+  function bootscore_container_class() {
+	return "container";
+  }
+}
+
+
+/**
+ * Make main content col dynamic if sidebar widgets exists
+ * @return string
+ */
+if ( !function_exists( 'bootscore_main_col_class' ) ) {
+  function bootscore_col_main_class() {
+    if (!is_active_sidebar('sidebar-1')) {
+      // Sidebar is empty
+      return "col";
+    } else {
+      // Sidebar has widgets
+      return "col-md-8 col-lg-9";
+    }
+  }
 }

--- a/index.php
+++ b/index.php
@@ -115,7 +115,7 @@ get_header();
       <?php endif; ?>
       <!-- Post List -->
       <div class="row">
-        <div class="col col-md-8 col-lg-9">
+        <div class="<?php echo bootscore_main_col_class(); ?>">
           <!-- Grid Layout -->
           <?php if (have_posts()) : ?>
             <?php while (have_posts()) : the_post(); ?>

--- a/page-templates/page-full-width-image.php
+++ b/page-templates/page-full-width-image.php
@@ -28,14 +28,20 @@ get_header();
         <!-- Hook to add something nice -->
         <?php bs_after_primary(); ?>
 
-        <div class="entry-content">
-          <?php the_content(); ?>
+        <div class="row">
+          <div class="<?php echo bootscore_main_col_class(); ?>">
+        
+            <div class="entry-content">
+              <?php the_content(); ?>
+            </div>
+
+            <footer class="entry-footer">
+              <?php comments_template(); ?>
+            </footer>
+
+          </div>
+          <?php get_sidebar(); ?>
         </div>
-
-        <footer class="entry-footer">
-          <?php comments_template(); ?>
-        </footer>
-
       </div>
 
     </main>

--- a/page-templates/page-sidebar-left.php
+++ b/page-templates/page-sidebar-left.php
@@ -19,7 +19,7 @@ get_header();
 
     <div class="row">
       <?php get_sidebar(); ?>
-      <div class="col-md-8 col-lg-9 order-first order-md-last">
+      <div class="<?php echo bootscore_main_col_class(); ?> order-first order-md-last">
 
         <main id="main" class="site-main">
 

--- a/page.php
+++ b/page.php
@@ -23,7 +23,7 @@ get_header();
     <?php bs_after_primary(); ?>
 
     <div class="row">
-      <div class="col-md-8 col-lg-9">
+      <div class="<?php echo bootscore_main_col_class(); ?>">
 
         <main id="main" class="site-main">
 

--- a/scss/bootscore/_admin_bar.scss
+++ b/scss/bootscore/_admin_bar.scss
@@ -14,6 +14,7 @@ Admin bar
   // Push content down when WP admin-bar is visible
   .fixed-top,
   .offcanvas:not(.offcanvas-bottom),
+  .offcanvas-md,
   .offcanvas-lg,
   .offcanvas-xl,
   .offcanvas-xxl,

--- a/search.php
+++ b/search.php
@@ -17,7 +17,7 @@ get_header();
     <?php bs_after_primary(); ?>
 
     <div class="row">
-      <div class="col">
+      <div class="<?php echo bootscore_main_col_class(); ?>">
 
         <main id="main" class="site-main">
 

--- a/single-templates/single-full-width-image.php
+++ b/single-templates/single-full-width-image.php
@@ -26,37 +26,44 @@ get_header();
         <?php bs_after_primary(); ?>
 
         <?php the_breadcrumb(); ?>
+        
+        <div class="row">
+          <div class="<?php echo bootscore_main_col_class(); ?>">
 
-        <div class="entry-content">
-          <?php bootscore_category_badge(); ?>
-          <p class="entry-meta">
-            <small class="text-muted">
-              <?php
-                bootscore_date();
-                bootscore_author();
-                bootscore_comment_count();
-              ?>
-            </small>
-          </p>
-          <?php the_content(); ?>
-        </div>
+            <div class="entry-content">
+              <?php bootscore_category_badge(); ?>
+              <p class="entry-meta">
+                <small class="text-muted">
+                  <?php
+                    bootscore_date();
+                    bootscore_author();
+                    bootscore_comment_count();
+                  ?>
+                </small>
+              </p>
+              <?php the_content(); ?>
+            </div>
 
-        <footer class="entry-footer clear-both">
-          <div class="mb-4">
-            <?php bootscore_tags(); ?>
+            <footer class="entry-footer clear-both">
+              <div class="mb-4">
+                <?php bootscore_tags(); ?>
+              </div>
+              <nav aria-label="bS page navigation">
+                <ul class="pagination justify-content-center">
+                  <li class="page-item">
+                    <?php previous_post_link('%link'); ?>
+                  </li>
+                  <li class="page-item">
+                    <?php next_post_link('%link'); ?>
+                  </li>
+                </ul>
+              </nav>
+              <?php comments_template(); ?>
+            </footer>
+            
           </div>
-          <nav aria-label="bS page navigation">
-            <ul class="pagination justify-content-center">
-              <li class="page-item">
-                <?php previous_post_link('%link'); ?>
-              </li>
-              <li class="page-item">
-                <?php next_post_link('%link'); ?>
-              </li>
-            </ul>
-          </nav>
-          <?php comments_template(); ?>
-        </footer>
+          <?php get_sidebar(); ?>
+        </div>
 
       </div>
 

--- a/single-templates/single-sidebar-left.php
+++ b/single-templates/single-sidebar-left.php
@@ -17,7 +17,7 @@ get_header();
 
     <div class="row">
       <?php get_sidebar(); ?>
-      <div class="col-md-8 col-lg-9 order-first order-md-last">
+      <div class="<?php echo bootscore_main_col_class(); ?> order-first order-md-last">
 
         <main id="main" class="site-main">
 

--- a/single.php
+++ b/single.php
@@ -15,7 +15,7 @@ get_header();
     <?php the_breadcrumb(); ?>
 
     <div class="row">
-      <div class="col-md-8 col-lg-9">
+      <div class="<?php echo bootscore_main_col_class(); ?>">
 
         <main id="main" class="site-main">
 

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -27,7 +27,7 @@ get_header();
       <!-- Breadcrumb -->
       <?php woocommerce_breadcrumb(); ?>
       <div class="row">
-        <div class="col">
+        <div class="<?php echo bootscore_main_col_class(); ?>">
           <?php woocommerce_content(); ?>
         </div>
         <!-- sidebar -->


### PR DESCRIPTION
Main content `col` must have a fixed width `<div class="col-md-8 col-lg-9">`. Dynamic `col` class isn't enough, because if content has e.g. a larger image `col` uses the entire screen width  and sidebar is pushed to bottom.

This PR replaces the fixed col width classes with function `<div class="<?php echo bootscore_main_col_class(); ?>">`, which returns to `<div class="col-md-8 col-lg-9">` if sidebar is active and to `<div class="col">` if no sidebar is active. In conclusion, if no sidebar is active, content uses entire width instead showing whitespace.