### PR TITLE
Hotfix password protected form

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -456,7 +456,7 @@ endif;
 if (!function_exists('bootscore_pw_form')) :
   function bootscore_pw_form() {
     $output = '
-        <form action="' . get_option('siteurl') . '/wp-login.php?action=postpass" method="post" class="input-group">' . "\n"
+        <form action="' . get_option('siteurl') . '/wp-login.php?action=postpass" method="post" class="input-group pw_form">' . "\n"
       . '<input name="post_password" type="password" size="" class="form-control" placeholder="' . __('Password', 'bootscore') . '"/>' . "\n"
       . '<input type="submit" class="btn btn-outline-primary input-group-text" name="Submit" value="' . __('Submit', 'bootscore') . '" />' . "\n"
       . '</form>' . "\n";

--- a/scss/bootscore/_recycle_bin.scss
+++ b/scss/bootscore/_recycle_bin.scss
@@ -18,6 +18,12 @@ p:empty:before {
   color: var(--#{$prefix}light) !important;
 }
 
+// Hotfix password protected input-group button
+.pw_form .btn {
+  border-top-right-radius: $btn-border-radius !important;
+  border-bottom-right-radius: $btn-border-radius !important;
+}
+
 
 // Fallback for previous horizontal card images
 // See https://github.com/bootscore/bootscore/issues/447


### PR DESCRIPTION
Fixes rough the input-group border-radius in pw protected form. Function creates `<br>` tags.

| Before  | After |
| ------------- | ------------- |
| <img width="471" alt="Bildschirmfoto 2023-05-30 um 11 48 10" src="https://github.com/bootscore/bootscore/assets/51531217/580be7c6-b767-4e5b-a898-9b821fbadbe6">  | <img width="477" alt="Bildschirmfoto 2023-05-30 um 11 47 36" src="https://github.com/bootscore/bootscore/assets/51531217/3e1cf895-366e-480c-b354-f075667ed25e">  |



