### PR TITLE
Changing ms-2 to ms-1 ms-md-2 in top-nav-widget

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -123,7 +123,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'name'          => esc_html__('Top Nav', 'bootscore'),
       'id'            => 'top-nav',
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
-      'before_widget' => '<div class="top-nav-widget ms-2">',
+      'before_widget' => '<div class="top-nav-widget ms-1 ms-md-2">',
       'after_widget'  => '</div>',
       'before_title'  => '<div class="widget-title d-none">',
       'after_title'   => '</div>'


### PR DESCRIPTION
Following  #511 
Changing `ms-2` to `ms-1 ms-md-2` in top-nav-widget. So if we add items or buttons via `wordpress admin panel` to the top-nav widget, one after another in different `HTML-code` container blocks, we would keep 0.25rem margin between them on mobile screens instead of ms-2, which would look too wide compared to margin between other elements (navbar-toggler, search, cart, user — all of them use ms-1 on mobile). So we won't see this:)
<img width="478" alt="123" src="https://github.com/bootscore/bootscore/assets/108526222/e6c1ac90-b9cc-49ce-b21b-0e9b9f9373cb">

Closes https://github.com/bootscore/bootscore/issues/511