### PR TITLE
Update WooCommerce 7.9 templates

### DIFF
--- a/woocommerce/cart/cart.php
+++ b/woocommerce/cart/cart.php
@@ -13,7 +13,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.8.0
+ * @version 7.9.0
  */
 
 defined('ABSPATH') || exit;
@@ -45,7 +45,10 @@ do_action('woocommerce_before_cart'); ?>
          * Filter the product name.
          *
          * @since 7.8.0
+         * @since 2.1.0
          * @param string $product_name Name of the product in the cart.
+         * @param array $cart_item The product in the cart.
+         * @param string $cart_item_key Key for the product in the cart.
          */
         $product_name = apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key );
  
@@ -62,7 +65,7 @@ do_action('woocommerce_before_cart'); ?>
                   '<a href="%s" class="text-danger" aria-label="%s" data-product_id="%s" data-product_sku="%s"><i class="fa-regular fa-trash-can"></i></a>',
                   esc_url(wc_get_cart_remove_url($cart_item_key)),
                   /* translators: %s is the product name */
-		          esc_attr( sprintf( __( 'Remove %s from cart', 'woocommerce' ), $product_name ) ),
+		          esc_attr( sprintf( __( 'Remove %s from cart', 'woocommerce' ), wp_strip_all_tags( $product_name ) ) ),
                   esc_attr($product_id),
                   esc_attr($_product->get_sku())
                 ),
@@ -86,23 +89,14 @@ do_action('woocommerce_before_cart'); ?>
             <td class="product-name" data-title="<?php esc_attr_e('Product', 'woocommerce'); ?>">
               <?php
               if (!$product_permalink) {
-                /**
-                 * Filter the product name.
-                 *
-                 * @since 7.8.0
-                 * @param string $product_name Name of the product in the cart.
-                 * @param array $cart_item The product in the cart.
-                 * @param string $cart_item_key Key for the product in the cart.
-                 */
-                echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', $product_name, $cart_item, $cart_item_key ) . '&nbsp;' );
+                echo wp_kses_post( $product_name . '&nbsp;' );
               } else {
                 /**
-                 * Filter the product name.
+                 * This filter is documented above.
                  *
-                 * @since 7.8.0
-                 * @param string $product_url URL the product in the cart.
+                 * @since 2.1.0
                  */
-                echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $product_name ), $cart_item, $cart_item_key ) );
+                echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $_product->get_name() ), $cart_item, $cart_item_key ) );
               }
 
               do_action('woocommerce_after_cart_item_name', $cart_item, $cart_item_key);

--- a/woocommerce/cart/mini-cart.php
+++ b/woocommerce/cart/mini-cart.php
@@ -15,7 +15,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.8.0
+ * @version 7.9.0
  */
 
 defined('ABSPATH') || exit;
@@ -34,9 +34,9 @@ do_action('woocommerce_before_mini_cart'); ?>
 
       if ($_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters('woocommerce_widget_cart_item_visible', true, $cart_item, $cart_item_key)) {
         /**
-         * Filter the product name.
+         * This filter is documented in woocommerce/templates/cart/cart.php.
          *
-         * @param string $product_name Name of the product in the cart.
+         @since 2.1.0
          */
         $product_name      = apply_filters('woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key);
         $thumbnail         = apply_filters('woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key);
@@ -84,7 +84,7 @@ do_action('woocommerce_before_mini_cart'); ?>
                   '<a href="%s" class="remove_from_cart_button text-danger" aria-label="%s" data-product_id="%s" data-cart_item_key="%s" data-product_sku="%s"><i class="fa-regular fa-trash-can"></i></a>',
                   esc_url(wc_get_cart_remove_url($cart_item_key)),
                   /* translators: %s is the product name */
-                  esc_attr(sprintf(__('Remove %s from cart', 'woocommerce'), $product_name)),
+                  esc_attr( sprintf( __( 'Remove %s from cart', 'woocommerce' ), wp_strip_all_tags( $product_name ) ) ),
                   esc_attr($product_id),
                   esc_attr($cart_item_key),
                   esc_attr($_product->get_sku())


### PR DESCRIPTION
This PR updates `cart.php` and `mini-cart.php` for upcoming WooCommerce 7.9 (July 11th) release. I hate maintaining WC templates, so this two files are the next ones on my removing list ;-)

Tested it with WC 7.8.2 as well and works fine, we can safely merge.

@justinkruit think we should https://github.com/bootscore/bootscore/pull/520 first. If both PR's are merged, I will prepare a release for 5.3.1 which we should ship on Monday. Agree?