### PR TITLE
5.3.1 Release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -9,7 +9,7 @@ Tags: featured-images, threaded-comments, translation-ready
 Requires at least: 4.5
 Tested up to: 6.2.2
 Requires PHP: 5.6
-Stable tag: 5.3.0
+Stable tag: 5.3.1
 License: MIT License
 License URI: https://github.com/bootscore/bootscore/blob/main/LICENSE
 
@@ -58,6 +58,12 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
 
 
 == Changelog ==
+
+    = 5.3.1 - July 10 2023 =
+    
+        *
+        *
+        *
 
     = 5.3.0 - June 2 2023 =
     

--- a/readme.txt
+++ b/readme.txt
@@ -61,9 +61,27 @@ bootScore includes support for WooCommerce and Infinite Scroll in Jetpack.
 
     = 5.3.1 - July 10 2023 =
     
-        *
-        *
-        *
+        * [DELETED] price.php ad1eba5
+        * [DELETED] form-lost-password.php 3c2f6c6
+        * [DELETED] form-edit-account.php fd863e2
+        * [DELETED] form-reset-password.php 617d663
+        * [DELETED] my-adress.php e78a5a3
+        * [DELETED] loop/sale-flash.php 6106302
+        * [DELETED] single-product/sale-flash.php 9246c3d
+        * [DELETED] my-account/form-login.php bd82f53
+        * [DELETED] global/form-login.php 8a2f1db
+        * [DELETED] order/order-details-customer.php 400631a
+        * [DELETED] cart/shipping-calculator.php f5449f1
+        * [DELETED] cart-shipping.php 15a4462
+        * [DELETED] form-shipping.php 9a9cc73
+        * [DELETED] form-billing.php 1dd17b5
+        * [FEATURE] Added a hook to all single-*.php's for related posts 367724b
+        * [UPDATE] WooCommerce 7.9 templates #525
+        * [UPDATE] Turkish translation #507
+        * [BUGFIX] Enqueue cart fragments script #508
+        * [IMPROVEMENT] Changing ms-2 to ms-1 ms-md-2 in top-nav-widget #512
+        * [IMPROVEMENT] Replace PHP echo with shorthand 4f5e9b7
+        * [IMPROVEMENT] Wrap *-full-width-image.php h1 in div cdb8a60
 
     = 5.3.0 - June 2 2023 =
     

--- a/scss/_bscore_style.scss
+++ b/scss/_bscore_style.scss
@@ -1,5 +1,5 @@
 /*!
- * bootScore 5.3.0 (https://bootscore.me/)
+ * bootScore 5.3.1 (https://bootscore.me/)
  */
 
 @import "bootscore/admin_bar";

--- a/scss/_bscore_woocommerce.scss
+++ b/scss/_bscore_woocommerce.scss
@@ -1,5 +1,5 @@
 /*!
- * bootScore WooCommerce 5.3.0 (https://bootscore.me/)
+ * bootScore WooCommerce 5.3.1 (https://bootscore.me/)
  */
 
 @import "bootscore_woocommerce/wc_ajax_cart";

--- a/single-templates/single-full-width-image.php
+++ b/single-templates/single-full-width-image.php
@@ -2,6 +2,8 @@
 /**
  * Template Name: Full width image
  * Template Post Type: post
+ *
+ * @version 5.3.1
  */
 
 get_header();
@@ -50,6 +52,8 @@ get_header();
                 <div class="mb-4">
                   <?php bootscore_tags(); ?>
                 </div>
+                <!-- Related posts using bS Swiper plugin -->
+                <?php if (function_exists('bootscore_related_posts')) bootscore_related_posts(); ?>
                 <nav aria-label="bS page navigation">
                   <ul class="pagination justify-content-center">
                     <li class="page-item">

--- a/single-templates/single-sidebar-left.php
+++ b/single-templates/single-sidebar-left.php
@@ -2,6 +2,8 @@
 /**
  * Template Name: Sidebar left
  * Template Post Type: post
+ *
+ * @version 5.3.1
  */
 
 get_header();
@@ -45,6 +47,8 @@ get_header();
               <div class="mb-4">
                 <?php bootscore_tags(); ?>
               </div>
+              <!-- Related posts using bS Swiper plugin -->
+              <?php if (function_exists('bootscore_related_posts')) bootscore_related_posts(); ?>
               <nav aria-label="bS page navigation">
                 <ul class="pagination justify-content-center">
                   <li class="page-item">

--- a/single-templates/single-sidebar-none.php
+++ b/single-templates/single-sidebar-none.php
@@ -2,6 +2,8 @@
 /**
  * Template Name: No Sidebar
  * Template Post Type: post
+ *
+ * @version 5.3.1
  */
 
 get_header();
@@ -41,6 +43,8 @@ get_header();
           <div class="mb-4">
             <?php bootscore_tags(); ?>
           </div>
+          <!-- Related posts using bS Swiper plugin -->
+          <?php if (function_exists('bootscore_related_posts')) bootscore_related_posts(); ?>
           <nav aria-label="bS page navigation">
             <ul class="pagination justify-content-center">
               <li class="page-item">

--- a/single.php
+++ b/single.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * Template Post Type: post
+ *
+ * @version 5.3.1
  */
 
 get_header();
@@ -43,6 +45,8 @@ get_header();
               <div class="mb-4">
                 <?php bootscore_tags(); ?>
               </div>
+              <!-- Related posts using bS Swiper plugin -->
+              <?php if (function_exists('bootscore_related_posts')) bootscore_related_posts(); ?>
               <nav aria-label="bS page navigation">
                 <ul class="pagination justify-content-center">
                   <li class="page-item">

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://bootscore.me/
 Author: bootScore
 Author URI: https://bootscore.me
 Description: A powerful Bootstrap 5 WordPress Starter Theme with WooCommerce Support. <a href="https://bootscore.me/category/documentation/" target="_blank">Documentation</a>. This theme gives you full control whatever you do and the full freedom to design whatever you want. It comes with a wide selection of category, page, post, author and archive templates as well as sidebar, header, footer and 404 widgets. There are no customizer settings in the backend. All settings can only be made by touching the code. Some CSS, HTML, PHP and JS Skills are required to customize it.
-Version: 5.3.0
+Version: 5.3.1
 Tested up to: 6.2.2
 Requires PHP: 5.6
 License: MIT License


### PR DESCRIPTION
This PR updates the version numbers and adds a hook to all `single-*php`'s. Tested it on some live-sites and works fine.

Some users asked for related posts and I think this is a nice feature. But we should not add this feature direct to the theme, we can use the Grid or Swiper plugin to do that. So, the plan is to add a related posts template to one of those plugins and if plugin is installed, related posts hook there. 

Here is a quick preview: https://intelligent-heizen.info/energieeffizient-bauen-so-gehts/. Scroll down to the bottom, above the pagination there are related posts showing the latest 12 posts from the same category using the bS Swiper plugin.

@justinkruit as usual, there is a drafted release ready to publish. 