### PR TITLE
Make qty always visible

### DIFF
--- a/scss/bootscore_woocommerce/_wc_breadcrumb.scss
+++ b/scss/bootscore_woocommerce/_wc_breadcrumb.scss
@@ -5,25 +5,32 @@ WooCommerce Breadcrumb
 .wc-breadcrumb {
 
   // Add a Fontawesome house icon for empty "Home" (wc-functions.php)
-  .breadcrumb-item:first-child a::before {
-    content: ' ';
-    display: inline-block;
-    width: $font-size-base;
-    height: 100%;
-    background-color: var(--#{$prefix}link-color);
-    mask-position: center;
-    mask-repeat: no-repeat;
-    mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' height='1em' viewBox='0 0 576 512'%3e%3c!--! Font Awesome Free 6.4.0 by %40fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons%2c Inc. --%3e%3cpath d='M575.8 255.5c0 18-15 32.1-32 32.1h-32l.7 160.2c0 2.7-.2 5.4-.5 8.1V472c0 22.1-17.9 40-40 40H456c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1H416 392c-22.1 0-40-17.9-40-40V448 384c0-17.7-14.3-32-32-32H256c-17.7 0-32 14.3-32 32v64 24c0 22.1-17.9 40-40 40H160 128.1c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2H104c-22.1 0-40-17.9-40-40V360c0-.9 0-1.9 .1-2.8V287.6H32c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z'/%3e%3c/svg%3e");
-    -webkit-mask-position: center;
-    -webkit-mask-repeat: no-repeat;
-    -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' height='1em' viewBox='0 0 576 512'%3e%3c!--! Font Awesome Free 6.4.0 by %40fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons%2c Inc. --%3e%3cpath d='M575.8 255.5c0 18-15 32.1-32 32.1h-32l.7 160.2c0 2.7-.2 5.4-.5 8.1V472c0 22.1-17.9 40-40 40H456c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1H416 392c-22.1 0-40-17.9-40-40V448 384c0-17.7-14.3-32-32-32H256c-17.7 0-32 14.3-32 32v64 24c0 22.1-17.9 40-40 40H160 128.1c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2H104c-22.1 0-40-17.9-40-40V360c0-.9 0-1.9 .1-2.8V287.6H32c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z'/%3e%3c/svg%3e");
-  }
+  .breadcrumb-item:first-child a {
 
-  // Additional code for wc breadcrumbs, 
-  // as the wc breadcrumb function does not allow for custom 
-  // class for last child
-  .breadcrumb-item:last-child {
-    color: var(--#{$prefix}breadcrumb-item-active-color);
-    padding-right: $spacer;
+    &::before {
+      content: ' ';
+      display: inline-block;
+      width: $font-size-base;
+      height: 100%;
+      background-color: var(--#{$prefix}link-color);
+      mask-position: center;
+      mask-repeat: no-repeat;
+      mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' height='1em' viewBox='0 0 576 512'%3e%3c!--! Font Awesome Free 6.4.0 by %40fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons%2c Inc. --%3e%3cpath d='M575.8 255.5c0 18-15 32.1-32 32.1h-32l.7 160.2c0 2.7-.2 5.4-.5 8.1V472c0 22.1-17.9 40-40 40H456c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1H416 392c-22.1 0-40-17.9-40-40V448 384c0-17.7-14.3-32-32-32H256c-17.7 0-32 14.3-32 32v64 24c0 22.1-17.9 40-40 40H160 128.1c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2H104c-22.1 0-40-17.9-40-40V360c0-.9 0-1.9 .1-2.8V287.6H32c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z'/%3e%3c/svg%3e");
+      -webkit-mask-position: center;
+      -webkit-mask-repeat: no-repeat;
+      -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' height='1em' viewBox='0 0 576 512'%3e%3c!--! Font Awesome Free 6.4.0 by %40fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons%2c Inc. --%3e%3cpath d='M575.8 255.5c0 18-15 32.1-32 32.1h-32l.7 160.2c0 2.7-.2 5.4-.5 8.1V472c0 22.1-17.9 40-40 40H456c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1H416 392c-22.1 0-40-17.9-40-40V448 384c0-17.7-14.3-32-32-32H256c-17.7 0-32 14.3-32 32v64 24c0 22.1-17.9 40-40 40H160 128.1c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2H104c-22.1 0-40-17.9-40-40V360c0-.9 0-1.9 .1-2.8V287.6H32c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z'/%3e%3c/svg%3e");
+    }
+
+    &:hover::before {
+      background-color: var(--#{$prefix}link-hover-color);
+    }
+
+    // Additional code for wc breadcrumbs, 
+    // as the wc breadcrumb function does not allow for custom 
+    // class for last child
+    .breadcrumb-item:last-child {
+      color: var(--#{$prefix}breadcrumb-item-active-color);
+      padding-right: $spacer;
+    }
   }
 }

--- a/scss/bootscore_woocommerce/_wc_cart.scss
+++ b/scss/bootscore_woocommerce/_wc_cart.scss
@@ -43,7 +43,6 @@ WooCommerce Cart
   // Fixed height for quantity cell in mobile cart if input is hidden
   // See _wc_qty_btn.scss
   .woocommerce-cart-form .product-quantity {
-    height: 57px;
 
     // Right align quantity input in mobile
     .quantity {

--- a/scss/bootscore_woocommerce/_wc_cart.scss
+++ b/scss/bootscore_woocommerce/_wc_cart.scss
@@ -50,11 +50,11 @@ WooCommerce Cart
     }
   }
 
-  // Coupon input in cart page
-  .woocommerce table.cart td.actions .coupon input,
-  .woocommerce-page #content table.cart td.actions .coupon input,
-  .woocommerce-page table.cart td.actions .coupon input {
-    width: 1%;
+  // Coupon button in cart page
+  .cart td.actions .coupon .button {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   // Update cart button

--- a/scss/bootscore_woocommerce/_wc_qty_btn.scss
+++ b/scss/bootscore_woocommerce/_wc_qty_btn.scss
@@ -17,11 +17,6 @@ WooCommerce Quantity Input
     }
   }
 
-  // Hide quantity if product is sold individually or only 1 in stock left
-  .quantity:has(.qty[type="hidden"]) {
-    display: none;
-  }
-
   // Input
   .qty {
     @extend .form-control;

--- a/woocommerce/wc-functions.php
+++ b/woocommerce/wc-functions.php
@@ -295,3 +295,25 @@ function bs_quantity_plus_button() {
 
 add_action('wp_header', 'bs_quantity_plus_minus');
 // Add -/+ buttons to quantity-input.php End
+
+
+/**
+ * This snippet can be used to force the quantity input to display in cases where
+ * the input value cannot be changed (which is when the product is set to be sold
+ * individually, or when the min and max values are identical).
+ * See https://github.com/woocommerce/woocommerce/pull/36460
+ */
+add_filter('woocommerce_quantity_input_args', function (array $args) {
+
+  if ($args['max_value'] < 1 || $args['min_value'] !== $args['max_value']) {
+    remove_filter('woocommerce_quantity_input_type', 'change_quantity_input_type');
+    return $args;
+  }
+  add_filter('woocommerce_quantity_input_type', 'change_quantity_input_type');
+  $args['readonly'] = true;
+  return $args;
+});
+
+function change_quantity_input_type() {
+  return 'number';
+}

--- a/woocommerce/wc-functions.php
+++ b/woocommerce/wc-functions.php
@@ -302,6 +302,7 @@ add_action('wp_header', 'bs_quantity_plus_minus');
  * the input value cannot be changed (which is when the product is set to be sold
  * individually, or when the min and max values are identical).
  * See https://github.com/woocommerce/woocommerce/pull/36460
+ * See https://github.com/bootscore/bootscore/pull/543/commits/57574c1fdd4ad10d296df70e51cf08b801fccb27
  */
 add_filter('woocommerce_quantity_input_args', function (array $args) {
 


### PR DESCRIPTION
Closes https://github.com/bootscore/bootscore/issues/538

Demo https://dev.bootscore.me/shop/

As discussed in https://github.com/bootscore/bootscore/pull/535, this PR makes the qty always visible and fixes overflow text in mobile cart coupon button for languages with longer words.

| Before | After |
| ------------- | ------------- |
| Default product  | No changes  |
| 1 in stock qty hidden  | 1 in stock qty visible but disabled  |
| Sold individually qty hidden  | Sold individually qty visible but disabled  |
| Cart 1 in stock qty visible, can be set to 0  | No changes  |
| Cart sold individually qty hidden  | Cart sold individually qty visible, can NOT be set to 0  |


| Before  | After |
| ------------- | ------------- |
| ![default-before](https://github.com/bootscore/bootscore/assets/51531217/968d4e71-e7d5-4f37-a888-f29c91e9ad97)  | ![default-after](https://github.com/bootscore/bootscore/assets/51531217/5a928892-0dde-4852-a1cd-f68381a7b86f)  |
| ![one-ins tock-before](https://github.com/bootscore/bootscore/assets/51531217/99dcdfb8-96b9-47bd-94c8-e07bef5d562e)  | ![one-in-stock-after](https://github.com/bootscore/bootscore/assets/51531217/840002c4-a49e-4924-bf90-c0752f9e17c0)  |
| ![sold-individually-before](https://github.com/bootscore/bootscore/assets/51531217/6cebd564-b83c-4799-99f9-d62a7852e741)  | ![sold-individually-after](https://github.com/bootscore/bootscore/assets/51531217/b75821b2-04ef-448d-94ba-e0d01e98f76a)  |
| ![cart-before](https://github.com/bootscore/bootscore/assets/51531217/6ce5a4f2-ef19-4da0-8438-54d5e4f1ba2e)  | ![cart-after](https://github.com/bootscore/bootscore/assets/51531217/f8aa2ab2-1d7f-4d7c-8b70-6c9f0dde3c6e)  |
| ![cart-mobile-before](https://github.com/bootscore/bootscore/assets/51531217/ff384a53-005e-43db-98a1-293039cdefdc)  | ![cart-mobile-after](https://github.com/bootscore/bootscore/assets/51531217/f0f9e4c6-c86d-4b33-87c0-80ff4e900b21)  |


Both products, 1 in stock and sold individually are not handled by WooCommerce in the same way. So, qty behaviour in cart is different. But both products are mostly edge cases.

I personally prefer to have the qty always visible and disabled if not more than one product can be added to the cart. But I am fine as well as we leave it as it is and hide qty in cart for sold individually products. 

@justinkruit if you like it, merge it. If you dislike it, close it. Think we should ship this with 5.3.2 https://github.com/bootscore/bootscore/pull/541 

Edit: Added a `:hover` state to WC breadcrumb home icon








