### PR TITLE
Exclude empty cart message from remove if offcanvas cart gets closed

### DIFF
--- a/woocommerce/inc/ajax-add-to-cart.php
+++ b/woocommerce/inc/ajax-add-to-cart.php
@@ -183,7 +183,7 @@ function bootscore_product_page_ajax_add_to_cart_js() {
 
       // Hide alert in offcanvas-cart when offcanvas is closed
       $('#offcanvas-cart').on('hidden.bs.offcanvas', function () {
-        $('#offcanvas-cart .woocommerce-message, #offcanvas-cart .woocommerce-error, #offcanvas-cart .woocommerce-info').remove();
+        $('#offcanvas-cart .woocommerce-message, #offcanvas-cart .woocommerce-error, #offcanvas-cart .woocommerce-info:not(.woocommerce-mini-cart__empty-message)').remove();
       });
 
       // Refresh ajax mini-cart on browser back button


### PR DESCRIPTION
https://github.com/bootscore/bootscore/pull/574/commits/07ec79f661bd50ccb44556604736c02e6e8e7525 added the `.woocommerce-info` selector. As a result, empty cart message removes if offcanvas cart opens twice. This PR excludes the empty cart message selector.

@justinkruit if you like it, merge it.