### PR TITLE
An adjustment that enables removing shop thumbnails in a supported way.

### DIFF
--- a/scss/bootscore_woocommerce/_wc_loop.scss
+++ b/scss/bootscore_woocommerce/_wc_loop.scss
@@ -43,9 +43,11 @@ WooCommerce Loop
   margin-top: auto;
 }
 
-
-// Categories
-// Category loop image
-.product-category .card img {
-  @extend .card-img-top;
+// Add .card-img-top to loop cards
+.product-category .card,
+.product.card {
+  img {
+    border-top-left-radius: $card-inner-border-radius;
+    border-top-right-radius: $card-inner-border-radius;
+  }
 }

--- a/woocommerce/inc/wc-loop.php
+++ b/woocommerce/inc/wc-loop.php
@@ -13,22 +13,6 @@ defined( 'ABSPATH' ) || exit;
 
 
 /**
- * Add card-img-top class to product loop
- */
-remove_action('woocommerce_before_shop_loop_item_title', 'woocommerce_template_loop_product_thumbnail', 10);
-add_action('woocommerce_before_shop_loop_item_title', 'custom_loop_product_thumbnail', 10);
-function custom_loop_product_thumbnail() {
-  global $product;
-  $size = 'woocommerce_thumbnail';
-  $code = 'class=card-img-top';
-
-  $image_size = apply_filters('single_product_archive_thumbnail_size', $size);
-
-  echo $product ? $product->get_image($image_size, $code) : '';
-}
-
-
-/**
  * Category loop button and badge
  */
 if (!function_exists('woocommerce_template_loop_category_title')) :


### PR DESCRIPTION
Per https://github.com/orgs/bootscore/discussions/597

This adjustment is in-line with effort to reduce WC templates #333

[IMPROVEMENT] Removed func custom_loop_product_thumbnail() from bootscore/woocommerce/inc/wc-loop.php

[IMPROVEMENT] Modified bootscore/woocommerce/inc/wc-loop.php to fetch both, category and product loop images

The above changes allow the following to work as expected:

// Remove product thumbnails from the shop loop:
remove_action( 'woocommerce_before_shop_loop_item_title', 'woocommerce_template_loop_product_thumbnail', 10 );

On branch reduce-WC-templates
Your branch is up to date with 'origin/reduce-WC-templates'.

Changes to be committed:
	modified:   scss/bootscore_woocommerce/_wc_loop.scss
	modified:   woocommerce/inc/wc-loop.php