### PR TITLE
HTML5 Compliance, Remove IE warning alert

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -41,17 +41,6 @@ function bootscore_scripts() {
   // Theme JS
   wp_enqueue_script('bootscore-script', get_template_directory_uri() . '/js/theme.js', array('jquery'), $modificated_themeJs, true);
 
-  // IE Warning
-  wp_localize_script('bootscore-script', 'bootscore', array(
-    'ie_title'                 => __('Internet Explorer detected', 'bootscore'),
-    'ie_limited_functionality' => __('This website will offer limited functionality in this browser.', 'bootscore'),
-    'ie_modern_browsers_1'     => __('Please use a modern and secure web browser like', 'bootscore'),
-    'ie_modern_browsers_2'     => __(' <a href="https://www.mozilla.org/firefox/" target="_blank">Mozilla Firefox</a>, <a href="https://www.google.com/chrome/" target="_blank">Google Chrome</a>, <a href="https://www.opera.com/" target="_blank">Opera</a> ', 'bootscore'),
-    'ie_modern_browsers_3'     => __('or', 'bootscore'),
-    'ie_modern_browsers_4'     => __(' <a href="https://www.microsoft.com/edge" target="_blank">Microsoft Edge</a> ', 'bootscore'),
-    'ie_modern_browsers_5'     => __('to display this site correctly.', 'bootscore'),
-  ));
-
   if (is_singular() && comments_open() && get_option('thread_comments')) {
     wp_enqueue_script('comment-reply');
   }

--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -32,7 +32,7 @@ if (!function_exists('bootscore_pagination')) :
     }
 
     if (1 != $pages) {
-      echo '<nav aria-label="Page navigation" role="navigation">';
+      echo '<nav aria-label="Page navigation">';
       echo '<span class="visually-hidden">' . esc_html__('Page navigation', 'bootscore') . '</span>';
       echo '<ul class="pagination justify-content-center mb-4">';
 

--- a/js/theme.js
+++ b/js/theme.js
@@ -44,13 +44,4 @@ jQuery(function ($) {
   $('.height-85').css('height', 0.85 * $(window).height());
   $('.height-100').css('height', 1.0 * $(window).height());
 
-  // IE Warning
-  if (window.document.documentMode) {
-    let IEWarningDiv = document.createElement('div');
-    IEWarningDiv.setAttribute('class', 'position-fixed top-0 end-0 bottom-0 start-0 d-flex justify-content-center align-items-center');
-    IEWarningDiv.setAttribute('style', 'background:white;z-index:1999');
-    IEWarningDiv.innerHTML = '<div style="max-width: 90vw;">' + '<h1>' + bootscore.ie_title + '</h1>' + '<p className="lead">' + bootscore.ie_limited_functionality + '</p>' + '<p className="lead">' + bootscore.ie_modern_browsers_1 + bootscore.ie_modern_browsers_2 + bootscore.ie_modern_browsers_3 + bootscore.ie_modern_browsers_4 + bootscore.ie_modern_browsers_5 + '</p>' + '</div>';
-    document.body.appendChild(IEWarningDiv);
-  }
-  // IE Warning End
 }); // jQuery End


### PR DESCRIPTION
- [Changed] Removed navigation role from nav element as per HTML5 standards. See #619 
- [Removed] Remove IE Support and warning. See #617 


Closes https://github.com/bootscore/bootscore/issues/619
Closes https://github.com/bootscore/bootscore/issues/617