### PR TITLE
Change footer `col-md-6` to `col-6`

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -8,7 +8,6 @@
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
  * @package Bootscore
- *
  * @version 5.4.0
  */
 

--- a/footer.php
+++ b/footer.php
@@ -31,28 +31,28 @@ defined( 'ABSPATH' ) || exit;
       <div class="row">
 
         <!-- Footer 1 Widget -->
-        <div class="col-md-6 col-lg-3">
+        <div class="col-6 col-lg-3">
           <?php if (is_active_sidebar('footer-1')) : ?>
             <?php dynamic_sidebar('footer-1'); ?>
           <?php endif; ?>
         </div>
 
         <!-- Footer 2 Widget -->
-        <div class="col-md-6 col-lg-3">
+        <div class="col-6 col-lg-3">
           <?php if (is_active_sidebar('footer-2')) : ?>
             <?php dynamic_sidebar('footer-2'); ?>
           <?php endif; ?>
         </div>
 
         <!-- Footer 3 Widget -->
-        <div class="col-md-6 col-lg-3">
+        <div class="col-6 col-lg-3">
           <?php if (is_active_sidebar('footer-3')) : ?>
             <?php dynamic_sidebar('footer-3'); ?>
           <?php endif; ?>
         </div>
 
         <!-- Footer 4 Widget -->
-        <div class="col-md-6 col-lg-3">
+        <div class="col-6 col-lg-3">
           <?php if (is_active_sidebar('footer-4')) : ?>
             <?php dynamic_sidebar('footer-4'); ?>
           <?php endif; ?>

--- a/footer.php
+++ b/footer.php
@@ -9,10 +9,14 @@
  *
  * @package Bootscore
  *
- * @version 5.3.0
+ * @version 5.4.0
  */
 
+// Exit if accessed directly
+defined( 'ABSPATH' ) || exit;
+
 ?>
+
 
 <footer>
 

--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -6,7 +6,7 @@
  * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
  *
  * @package Bootscore 
- * @version 5.3.3
+ * @version 5.4.0
  */
 
 
@@ -91,7 +91,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'name'          => esc_html__('Footer 1', 'bootscore'),
       'id'            => 'footer-1',
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
-      'before_widget' => '<div class="footer_widget mb-4">',
+      'before_widget' => '<div class="footer_widget mb-3">',
       'after_widget'  => '</div>',
       'before_title'  => '<h2 class="widget-title h5">',
       'after_title'   => '</h2>'
@@ -102,7 +102,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'name'          => esc_html__('Footer 2', 'bootscore'),
       'id'            => 'footer-2',
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
-      'before_widget' => '<div class="footer_widget mb-4">',
+      'before_widget' => '<div class="footer_widget mb-3">',
       'after_widget'  => '</div>',
       'before_title'  => '<h2 class="widget-title h5">',
       'after_title'   => '</h2>'
@@ -113,7 +113,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'name'          => esc_html__('Footer 3', 'bootscore'),
       'id'            => 'footer-3',
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
-      'before_widget' => '<div class="footer_widget mb-4">',
+      'before_widget' => '<div class="footer_widget mb-3">',
       'after_widget'  => '</div>',
       'before_title'  => '<h2 class="widget-title h5">',
       'after_title'   => '</h2>'
@@ -124,7 +124,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'name'          => esc_html__('Footer 4', 'bootscore'),
       'id'            => 'footer-4',
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
-      'before_widget' => '<div class="footer_widget mb-4">',
+      'before_widget' => '<div class="footer_widget mb-3">',
       'after_widget'  => '</div>',
       'before_title'  => '<h2 class="widget-title h5">',
       'after_title'   => '</h2>'


### PR DESCRIPTION
This PR changes the footer widget 1-4 `col-md-6` to `col-6` and the bottom margin from `mb-4` to `mb-3`. Less whitespace and a much more modern look & feel.

@justinkruit if you like it, merge it.

| Before  | After |
| ------------- | ------------- |
| ![footer-1](https://github.com/bootscore/bootscore/assets/51531217/f1bada1d-b0d2-4bbf-9929-839adddc68ad)  | ![footer-2](https://github.com/bootscore/bootscore/assets/51531217/69dc1243-66d7-4f42-8887-4ca51f5a2fb8)  |






