### PR TITLE
Fix responsive tables

### DIFF
--- a/scss/_bscore_style.scss
+++ b/scss/_bscore_style.scss
@@ -16,6 +16,7 @@
 @import "bootscore/markups";
 @import "bootscore/recycle_bin";
 @import "bootscore/single";
+@import "bootscore/tables";
 @import "bootscore/top_button";
 @import "bootscore/utilities";
 @import "bootscore/widgets";

--- a/scss/bootscore/_tables.scss
+++ b/scss/bootscore/_tables.scss
@@ -1,0 +1,19 @@
+/*--------------------------------------------------------------
+Tables
+--------------------------------------------------------------*/
+
+// Theme uses word-break: break-word; on body as recommended by WordPress to handle edge cases.
+// See https://dev.bootscore.me/2009/10/05/title-should-not-overflow-the-content-area/
+// As result, words break in tables and responsive tables aren't responsive.
+// Adding white-space: nowrap; to tables to each breakpoint solves this.
+@each $breakpoint in map-keys($grid-breakpoints) {
+  $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+  @include media-breakpoint-down($breakpoint) {
+    .table-responsive#{$infix} {
+      .table {
+        white-space: nowrap;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Theme uses 

```css
body {
  word-break: break-word;
}
```
as recommended by WordPress to handle edge cases https://dev.bootscore.me/2009/10/05/title-should-not-overflow-the-content-area/.

As result, words break in tables and responsive tables aren't responsive. Adding `white-space: nowrap;` to tables to each breakpoint solves this.

| Before  | After |
| ------------- | ------------- |
| <img width="337" alt="break-word" src="https://github.com/bootscore/bootscore/assets/51531217/92c09094-a5ed-480c-9e53-12e5a2bb3bfc">  | <img width="337" alt="white-space" src="https://github.com/bootscore/bootscore/assets/51531217/3269989e-363e-41d0-981b-7f9c1546332b">  |





