### PR TITLE
Rewrite main.scss

### DIFF
--- a/scss/_bscore_utilities.scss
+++ b/scss/_bscore_utilities.scss
@@ -1,0 +1,4 @@
+/*
+  Use this file to add your own custom utility classes.
+  https://getbootstrap.com/docs/5.3/utilities/api/
+*/

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -46,6 +46,8 @@
 @import "bootstrap/offcanvas";
 @import "bootstrap/placeholders";
 
+@import "bootstrap/helpers";
+
 @import "bootstrap/utilities/api";
 
 @import "bscore_style";

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -19,6 +19,8 @@
 @import "bootstrap/grid";
 @import "bootstrap/helpers";
 
+@import "bscore_utilities";
+
 @import "bootstrap/utilities/api";
 
 @import "bscore_style";

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -12,6 +12,8 @@
 
 @import "bootstrap/utilities";
 
+@import "bscore_utilities";
+
 @import "bootstrap/root";
 @import "bootstrap/reboot";
 @import "bootstrap/type";
@@ -43,8 +45,6 @@
 @import "bootstrap/spinners";
 @import "bootstrap/offcanvas";
 @import "bootstrap/placeholders";
-
-@import "bscore_utilities";
 
 @import "bootstrap/utilities/api";
 

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -9,15 +9,40 @@
 
 @import "bootstrap/maps";
 @import "bootstrap/mixins";
-@import "bootstrap/root";
 
 @import "bootstrap/utilities";
+
+@import "bootstrap/root";
 @import "bootstrap/reboot";
 @import "bootstrap/type";
 @import "bootstrap/images";
 @import "bootstrap/containers";
 @import "bootstrap/grid";
-@import "bootstrap/helpers";
+@import "bootstrap/tables";
+@import "bootstrap/forms";
+@import "bootstrap/buttons";
+@import "bootstrap/transitions";
+@import "bootstrap/dropdown";
+@import "bootstrap/button-group";
+@import "bootstrap/nav";
+@import "bootstrap/navbar";
+@import "bootstrap/card";
+@import "bootstrap/accordion";
+@import "bootstrap/breadcrumb";
+@import "bootstrap/pagination";
+@import "bootstrap/badge";
+@import "bootstrap/alert";
+@import "bootstrap/progress";
+@import "bootstrap/list-group";
+@import "bootstrap/close";
+@import "bootstrap/toasts";
+@import "bootstrap/modal";
+@import "bootstrap/tooltip";
+@import "bootstrap/popover";
+@import "bootstrap/carousel";
+@import "bootstrap/spinners";
+@import "bootstrap/offcanvas";
+@import "bootstrap/placeholders";
 
 @import "bscore_utilities";
 

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -1,5 +1,24 @@
+@import "bootstrap/functions";
+
 @import "bscore_variables";
-@import "bootstrap/bootstrap";
+
+@import "bootstrap/variables";
+@import "bootstrap/variables-dark";
+
+@import "bootstrap/maps";
+@import "bootstrap/mixins";
+@import "bootstrap/root";
+
+@import "bootstrap/utilities";
+@import "bootstrap/reboot";
+@import "bootstrap/type";
+@import "bootstrap/images";
+@import "bootstrap/containers";
+@import "bootstrap/grid";
+@import "bootstrap/helpers";
+
+@import "bootstrap/utilities/api";
+
 @import "bscore_style";
 @import "bscore_woocommerce"; // Comment or delete this line if WooCommerce styles are not needed
 @import "bscore_custom";

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -5,6 +5,8 @@
 @import "bootstrap/variables";
 @import "bootstrap/variables-dark";
 
+@import "bscore_maps";
+
 @import "bootstrap/maps";
 @import "bootstrap/mixins";
 @import "bootstrap/root";


### PR DESCRIPTION
In issue #640 we highlighted that a rewrite of the `main.scss` is needed to give the users more control over Bootstrap. With this PR that will be achieved.

The variables are set before Bootstrap so everything is better overridable. 
A new `_bscore_maps.scss` has been added so maps can also be overridden. 
And lastly a new `_bscore_utilities.scss` has been added and loaded _after_ the Bootstrap utilities so they can be added upon ([docs](https://getbootstrap.com/docs/5.3/utilities/api/#using-the-api)).

I've tested the compiling locally, and nothing seems to be missing.

@crftwrk If you like it, merge it. 😜 