### PR TITLE
Remove filter to enable classic widgets by default

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *
  * @package Bootscore
- * @version 5.3.3
+ * @version 5.4.0
  */
 
 

--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -15,15 +15,6 @@ defined( 'ABSPATH' ) || exit;
 
 
 /**
- * Disable Gutenberg blocks in widgets (WordPress 5.8)
- */
-// Disables the block editor from managing widgets in the Gutenberg plugin.
-add_filter( 'gutenberg_use_widgets_block_editor', '__return_false' );
-// Disables the block editor from managing widgets.
-add_filter( 'use_widgets_block_editor', '__return_false' );
-
-
-/**
  * Register widgets
  */
 if (!function_exists('bootscore_widgets_init')) :


### PR DESCRIPTION
This PR removes the filter which enables classic widgets by default. I think we should let users decide by them self if they want to use Gutenberg or classic widgets by adding the filter to their child or installing the https://wordpress.org/plugins/classic-widgets/ plugin. 

The reason why I've added the filters was the search widget. Now Gutenberg search widget is used which is very ugly, but maybe this forces us to do something more to support blocks. When PR is merged, I will fix the Gutenberg search block.

@justinkruit IYLIMI!