### PR TITLE
Fix WC pagination.php

### DIFF
--- a/woocommerce/loop/pagination.php
+++ b/woocommerce/loop/pagination.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Pagination - Show numbered pagination for catalog pages
  *
@@ -11,7 +10,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://woo.com/document/template-structure/
  * @package WooCommerce\Templates
  * @version 3.3.1
  */
@@ -29,7 +28,46 @@ if ($total <= 1) {
   return;
 }
 ?>
-<!-- Pagination -->
-<div>
-  <?php bootscore_pagination(); ?>
-</div>
+<nav aria-label="wc-navigation">
+  <?php
+  $paginate_links =  paginate_links(
+    apply_filters(
+      'woocommerce_pagination_args',
+      array(
+        'base'         => $base,
+        'format'       => $format,
+        'add_args'     => false,
+        'current'      => max(1, $current),
+        'total'        => $total,
+        'prev_text'    => '&laquo;',
+        'next_text'    => '&raquo;',
+        'type'         => 'array',
+        'end_size'     => 1,
+        'mid_size'     => 1,
+      )
+    )
+  );
+
+  if (is_array($paginate_links)) {
+  ?>
+    <ul class="pagination justify-content-center">
+      <?php
+      foreach ($paginate_links as $paginate_link) {
+        // Replace 'page-numbers' with 'page-link' and 'current' with 'active'.
+        $paginate_link = str_replace(array('page-numbers', 'current'), array('page-link', 'active'), $paginate_link);
+      ?>
+
+        <li class="page-item">
+          <?php
+          echo wp_kses_post($paginate_link);
+          ?>
+        </li>
+
+      <?php
+      }
+      ?>
+    </ul>
+  <?php
+  }
+  ?>
+</nav>


### PR DESCRIPTION
Closes https://github.com/bootscore/bootscore/issues/661

Demo https://dev.bootscore.me/shop/wc-shortcodes/

This PR fixes the WC pagination if a shortcode has limited products and pagination is set to true `[products on_sale="true" per_page="2" paginate="true"]`.

@justinkruit IYLIMI