### PR TITLE
Add theme support for block template-parts

### DIFF
--- a/inc/theme-setup.php
+++ b/inc/theme-setup.php
@@ -4,7 +4,7 @@
  * Theme setup
  *
  * @package Bootscore 
- * @version 5.3.4
+ * @version 5.4.0
  */
 
 
@@ -32,7 +32,9 @@ if (!function_exists('bootscore_setup')) :
     */
     load_theme_textdomain('bootscore', get_template_directory() . '/languages');
 
-    // Add default posts and comments RSS feed links to head.
+    /*
+     * Add default posts and comments RSS feed links to head.
+    */
     add_theme_support('automatic-feed-links');
 
     /*
@@ -64,8 +66,15 @@ if (!function_exists('bootscore_setup')) :
       'style',
     ));
 
-    // Add theme support for selective refresh for widgets.
+    /*
+     * Add theme support for selective refresh for widgets.
+    */
     add_theme_support('customize-selective-refresh-widgets');
+    
+    /*
+     * Add theme support for block template-parts.
+    */
+    add_theme_support( 'block-template-parts' );    
   }
 endif;
 add_action('after_setup_theme', 'bootscore_setup');


### PR DESCRIPTION
This PR allows to use blocks as template parts. In Backend Appearance > Template Parts can now the mini-cart edited in more detail and we can hard code it in the theme like https://github.com/woocommerce/storefront/pull/2100.

Think in the long-term, our offcanvas-cart should be replaced by the mini-cart block https://github.com/bootscore/bootscore/issues/631.

Did roughly some changes to demonstrate how it works:

- Go to https://dev.bootscore.me/shop/ and add something to the cart
- Scroll down to the footer, there you will find the Woo mini-cart block. Open cart and check buttons, they have classes `btn btn-primary` etc.

@justinkruit IYLIMI