### PR TITLE
Rename some new filters

### DIFF
--- a/404.php
+++ b/404.php
@@ -14,7 +14,7 @@ defined('ABSPATH') || exit;
 
 get_header();
 ?>
-  <div id="content" class="site-content <?= apply_filters('bootscore/container_class', 'container', '404'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', '404'); ?>">
+  <div id="content" class="site-content <?= apply_filters('bootscore/class/container', 'container', '404'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', '404'); ?>">
     <div id="primary" class="content-area">
 
       <main id="main" class="site-main">

--- a/archive.php
+++ b/archive.php
@@ -15,11 +15,11 @@ defined('ABSPATH') || exit;
 get_header();
 ?>
 
-  <div id="content" class="site-content <?= apply_filters('bootscore/container_class', 'container', 'archive'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', 'archive'); ?>">
+  <div id="content" class="site-content <?= apply_filters('bootscore/class/container', 'container', 'archive'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', 'archive'); ?>">
     <div id="primary" class="content-area">
 
       <div class="row">
-        <div class="<?= apply_filters('bootscore/main/col_class', 'col') ?>">
+        <div class="<?= apply_filters('bootscore/class/col/main', 'col') ?>">
 
           <main id="main" class="site-main">
 

--- a/footer.php
+++ b/footer.php
@@ -19,8 +19,8 @@ defined('ABSPATH') || exit;
 
 <footer>
 
-  <div class="<?= apply_filters('bootscore/footer_class', 'bg-body-tertiary pt-5 pb-3'); ?> bootscore-footer">
-    <div class="<?= apply_filters('bootscore/container_class', 'container', 'footer'); ?>">
+  <div class="<?= apply_filters('bootscore/class/footer', 'bg-body-tertiary pt-5 pb-3'); ?> bootscore-footer">
+    <div class="<?= apply_filters('bootscore/class/container', 'container', 'footer'); ?>">
 
       <!-- Top Footer Widget -->
       <?php if (is_active_sidebar('top-footer')) : ?>
@@ -75,8 +75,8 @@ defined('ABSPATH') || exit;
     </div>
   </div>
 
-  <div class="<?= apply_filters('bootscore/footer_info_class', 'bg-body-tertiary text-body-secondary border-top py-2 text-center small'); ?> bootscore-info">
-    <div class="<?= apply_filters('bootscore/container_class', 'container', 'footer-info'); ?>">
+  <div class="<?= apply_filters('bootscore/class/footer_info', 'bg-body-tertiary text-body-secondary border-top py-2 text-center small'); ?> bootscore-info">
+    <div class="<?= apply_filters('bootscore/class/container', 'container', 'footer-info'); ?>">
       <?php if (is_active_sidebar('footer-info')) : ?>
         <?php dynamic_sidebar('footer-info'); ?>
       <?php endif; ?>
@@ -87,7 +87,7 @@ defined('ABSPATH') || exit;
 </footer>
 
 <!-- To top button -->
-<a href="#" class="<?= apply_filters('bootscore/to_top_button_class', 'btn btn-primary shadow'); ?> position-fixed zi-1020 top-button"><i class="fa-solid fa-chevron-up"></i><span class="visually-hidden-focusable">To top</span></a>
+<a href="#" class="<?= apply_filters('bootscore/class/to_top_button', 'btn btn-primary shadow'); ?> position-fixed zi-1020 top-button"><i class="fa-solid fa-chevron-up"></i><span class="visually-hidden-focusable">To top</span></a>
 
 </div><!-- #page -->
 

--- a/header.php
+++ b/header.php
@@ -90,7 +90,7 @@ defined('ABSPATH') || exit;
           ?>
 
           <!-- Navbar Toggler -->
-          <button class="<?= apply_filters('bootscore/header_button_class', 'btn btn-outline-secondary'); ?> d-lg-none ms-1 ms-md-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-navbar" aria-controls="offcanvas-navbar">
+          <button class="<?= apply_filters('bootscore/header/button_class', 'btn btn-outline-secondary', 'menu'); ?> d-lg-none ms-1 ms-md-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-navbar" aria-controls="offcanvas-navbar">
             <i class="fa-solid fa-bars"></i><span class="visually-hidden-focusable">Menu</span>
           </button>
 

--- a/header.php
+++ b/header.php
@@ -36,11 +36,11 @@ defined('ABSPATH') || exit;
     <?php dynamic_sidebar('top-bar'); ?>
   <?php endif; ?>  
 
-  <header id="masthead" class="<?= apply_filters('bootscore/header_class', 'sticky-top bg-body-tertiary'); ?> site-header">
+  <header id="masthead" class="<?= apply_filters('bootscore/class/header', 'sticky-top bg-body-tertiary'); ?> site-header">
 
     <nav id="nav-main" class="navbar navbar-expand-lg">
 
-      <div class="<?= apply_filters('bootscore/container_class', 'container', 'header'); ?>">
+      <div class="<?= apply_filters('bootscore/class/container', 'container', 'header'); ?>">
         <!-- Navbar Brand -->
         <a class="navbar-brand xs d-md-none" href="<?= esc_url(home_url()); ?>"><img src="<?= esc_url(apply_filters('bootscore/logo', get_stylesheet_directory_uri() . '/assets/img/logo/logo-sm.svg', 'small')); ?>" alt="logo" class="logo xs"></a>
         <a class="navbar-brand md d-none d-md-block" href="<?= esc_url(home_url()); ?>"><img src="<?= esc_url(apply_filters('bootscore/logo', get_stylesheet_directory_uri() . '/assets/img/logo/logo.svg', 'normal')); ?>" alt="logo" class="logo md"></a>
@@ -90,7 +90,7 @@ defined('ABSPATH') || exit;
           ?>
 
           <!-- Navbar Toggler -->
-          <button class="<?= apply_filters('bootscore/header/button_class', 'btn btn-outline-secondary', 'menu'); ?> d-lg-none ms-1 ms-md-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-navbar" aria-controls="offcanvas-navbar">
+          <button class="<?= apply_filters('bootscore/class/header_button', 'btn btn-outline-secondary', 'menu'); ?> d-lg-none ms-1 ms-md-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-navbar" aria-controls="offcanvas-navbar">
             <i class="fa-solid fa-bars"></i><span class="visually-hidden-focusable">Menu</span>
           </button>
 

--- a/inc/columns.php
+++ b/inc/columns.php
@@ -27,5 +27,5 @@ function bootscore_main_col_class_sidebar($string) {
   return $string;
 }
 
-add_filter('bootscore/main/col_class', 'bootscore_main_col_class_sidebar');
+add_filter('bootscore/class/col/main', 'bootscore_main_col_class_sidebar');
 

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -60,11 +60,11 @@ add_filter('widget_text', 'do_shortcode');
  * If so, we transform them to use the new filter hooks
  */
 if (function_exists('bootscore_main_col_class')) {
-  add_filter('bootscore/main/col_class', 'bootscore_main_col_class', 100);
+  add_filter('bootscore/class/col/main', 'bootscore_main_col_class', 100);
 }
 
 if (function_exists('bootscore_sidebar_col_class')) {
-  add_filter('bootscore/sidebar/col_class', 'bootscore_sidebar_col_class', 100);
+  add_filter('bootscore/class/col/sidebar', 'bootscore_sidebar_col_class', 100);
 }
 
 if (function_exists('bootscore_sidebar_toggler_class')) {
@@ -76,7 +76,7 @@ if (function_exists('bootscore_sidebar_offcanvas_class')) {
 }
 
 if (function_exists('bootscore_container_class')) {
-  add_filter('bootscore/container_class', 'bootscore_container_class', 100);
+  add_filter('bootscore/class/container', 'bootscore_container_class', 100);
 }
 
 

--- a/index.php
+++ b/index.php
@@ -19,7 +19,7 @@ defined('ABSPATH') || exit;
 
 get_header();
 ?>
-  <div id="content" class="site-content <?= apply_filters('bootscore/container_class', 'container', 'index'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', 'index'); ?>">
+  <div id="content" class="site-content <?= apply_filters('bootscore/class/container', 'container', 'index'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', 'index'); ?>">
     <div id="primary" class="content-area">
 
       <main id="main" class="site-main">
@@ -116,7 +116,7 @@ get_header();
         <?php endif; ?>
         <!-- Post List -->
         <div class="row">
-          <div class="<?= apply_filters('bootscore/main/col_class', 'col'); ?>">
+          <div class="<?= apply_filters('bootscore/class/col/main', 'col'); ?>">
             <!-- Grid Layout -->
             <?php if (have_posts()) : ?>
               <?php while (have_posts()) : the_post(); ?>

--- a/page-templates/page-blank-with-container.php
+++ b/page-templates/page-blank-with-container.php
@@ -15,7 +15,7 @@ defined('ABSPATH') || exit;
 get_header();
 ?>
 
-  <div id="content" class="site-content <?= apply_filters('bootscore/container_class', 'container', 'page-blank-with-container'); ?>">
+  <div id="content" class="site-content <?= apply_filters('bootscore/class/container', 'container', 'page-blank-with-container'); ?>">
     <div id="primary" class="content-area">
 
       <main id="main" class="site-main">

--- a/page-templates/page-full-width-image.php
+++ b/page-templates/page-full-width-image.php
@@ -22,17 +22,17 @@ get_header();
 
         <?php $thumb = wp_get_attachment_image_src(get_post_thumbnail_id($post->ID), 'full'); ?>
         <div class="entry-header featured-full-width-img height-75 bg-dark text-light mb-4" style="background-image: url('<?= $thumb['0']; ?>')">
-          <div class="<?= apply_filters('bootscore/container_class', 'container', 'page-full-width-image'); ?> entry-header h-100 d-flex align-items-end pb-3">
+          <div class="<?= apply_filters('bootscore/class/container', 'container', 'page-full-width-image'); ?> entry-header h-100 d-flex align-items-end pb-3">
             <div>
               <h1 class="entry-title"><?php the_title(); ?></h1>
             </div>
           </div>
         </div>
 
-        <div class="<?= apply_filters('bootscore/container_class', 'container', 'page-full-width-image'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pb-5', 'page-full-width-image'); ?>">
+        <div class="<?= apply_filters('bootscore/class/container', 'container', 'page-full-width-image'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pb-5', 'page-full-width-image'); ?>">
 
           <div class="row">
-            <div class="<?= apply_filters('bootscore/main/col_class', 'col'); ?>">
+            <div class="<?= apply_filters('bootscore/class/col/main', 'col'); ?>">
 
               <div class="entry-content">
                 <?php the_content(); ?>

--- a/page-templates/page-sidebar-left.php
+++ b/page-templates/page-sidebar-left.php
@@ -15,12 +15,12 @@ defined('ABSPATH') || exit;
 get_header();
 ?>
 
-  <div id="content" class="site-content <?= apply_filters('bootscore/container_class', 'container', 'page-sidebar-left'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', 'page-sidebar-left'); ?>">
+  <div id="content" class="site-content <?= apply_filters('bootscore/class/container', 'container', 'page-sidebar-left'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', 'page-sidebar-left'); ?>">
     <div id="primary" class="content-area">
 
       <div class="row">
         <?php get_sidebar(); ?>
-        <div class="<?= apply_filters('bootscore/main/col_class', 'col'); ?> order-first order-md-last">
+        <div class="<?= apply_filters('bootscore/class/col/main', 'col'); ?> order-first order-md-last">
 
           <main id="main" class="site-main">
 

--- a/page-templates/page-sidebar-none.php
+++ b/page-templates/page-sidebar-none.php
@@ -15,7 +15,7 @@ defined('ABSPATH') || exit;
 get_header();
 ?>
 
-  <div id="content" class="site-content <?= apply_filters('bootscore/container_class', 'container', 'page-sidebar-none'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', 'page-sidebar-none'); ?>">
+  <div id="content" class="site-content <?= apply_filters('bootscore/class/container', 'container', 'page-sidebar-none'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', 'page-sidebar-none'); ?>">
     <div id="primary" class="content-area">
 
       <main id="main" class="site-main">

--- a/page.php
+++ b/page.php
@@ -20,11 +20,11 @@ defined('ABSPATH') || exit;
 get_header();
 ?>
 
-  <div id="content" class="site-content <?= apply_filters('bootscore/container_class', 'container', 'page'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', 'page'); ?>">
+  <div id="content" class="site-content <?= apply_filters('bootscore/class/container', 'container', 'page'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', 'page'); ?>">
     <div id="primary" class="content-area">
 
       <div class="row">
-        <div class="<?= apply_filters('bootscore/main/col_class', 'col'); ?>">
+        <div class="<?= apply_filters('bootscore/class/col/main', 'col'); ?>">
 
           <main id="main" class="site-main">
 

--- a/search.php
+++ b/search.php
@@ -14,11 +14,11 @@ defined('ABSPATH') || exit;
 
 get_header();
 ?>
-  <div id="content" class="site-content <?= apply_filters('bootscore/container_class', 'container', 'search'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', 'search'); ?>">
+  <div id="content" class="site-content <?= apply_filters('bootscore/class/container', 'container', 'search'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-4 pb-5', 'search'); ?>">
     <div id="primary" class="content-area">
 
       <div class="row">
-        <div class="<?= apply_filters('bootscore/main/col_class', 'col'); ?>">
+        <div class="<?= apply_filters('bootscore/class/col/main', 'col'); ?>">
 
           <main id="main" class="site-main">
 

--- a/sidebar.php
+++ b/sidebar.php
@@ -18,14 +18,14 @@ if (!is_active_sidebar('sidebar-1')) {
   return;
 }
 ?>
-<div class="<?= apply_filters('bootscore/sidebar/col_class', 'col-lg-3 order-first order-lg-last'); ?>">
+<div class="<?= apply_filters('bootscore/class/col/sidebar', 'col-lg-3 order-first order-lg-last'); ?>">
   <aside id="secondary" class="widget-area">
 
-    <button class="<?= apply_filters('bootscore/sidebar/toggler_class', 'd-lg-none btn btn-outline-primary w-100 mb-4 d-flex justify-content-between align-items-center') ?>" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebar" aria-controls="sidebar">
+    <button class="<?= apply_filters('bootscore/class/sidebar/button', 'd-lg-none btn btn-outline-primary w-100 mb-4 d-flex justify-content-between align-items-center') ?>" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebar" aria-controls="sidebar">
       <?php esc_html_e('Open side menu', 'bootscore'); ?> <i class="fa-solid fa-ellipsis-vertical"></i>
     </button>
 
-    <div class="<?= apply_filters('bootscore/sidebar/offcanvas_class', 'offcanvas-lg offcanvas-end') ?>" tabindex="-1" id="sidebar" aria-labelledby="sidebarLabel">
+    <div class="<?= apply_filters('bootscore/class/sidebar/offcanvas', 'offcanvas-lg offcanvas-end') ?>" tabindex="-1" id="sidebar" aria-labelledby="sidebarLabel">
       <div class="offcanvas-header">
         <span class="h5 offcanvas-title" id="sidebarLabel"><?php esc_html_e('Sidebar', 'bootscore'); ?></span>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" data-bs-target="#sidebar" aria-label="Close"></button>

--- a/single-templates/single-full-width-image.php
+++ b/single-templates/single-full-width-image.php
@@ -21,19 +21,19 @@ get_header();
         <?php the_post(); ?>
         <?php $thumb = wp_get_attachment_image_src(get_post_thumbnail_id($post->ID), 'full'); ?>
         <div class="entry-header featured-full-width-img height-75 bg-dark text-light" style="background-image: url('<?= $thumb['0']; ?>')">
-          <div class="<?= apply_filters('bootscore/container_class', 'container', 'single-full-width-image'); ?> entry-header h-100 d-flex align-items-end pb-3">
+          <div class="<?= apply_filters('bootscore/class/container', 'container', 'single-full-width-image'); ?> entry-header h-100 d-flex align-items-end pb-3">
             <div>
               <h1 class="entry-title"><?php the_title(); ?></h1>
             </div>
           </div>
         </div>
 
-        <div class="<?= apply_filters('bootscore/container_class', 'container', 'single-full-width-image'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-3 pb-5', 'single-full-width-image'); ?>">
+        <div class="<?= apply_filters('bootscore/class/container', 'container', 'single-full-width-image'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-3 pb-5', 'single-full-width-image'); ?>">
 
           <?php the_breadcrumb(); ?>
 
           <div class="row">
-            <div class="<?= apply_filters('bootscore/main/col_class', 'col'); ?>">
+            <div class="<?= apply_filters('bootscore/class/col/main', 'col'); ?>">
 
               <div class="entry-content">
                 <?php bootscore_category_badge(); ?>

--- a/single-templates/single-sidebar-left.php
+++ b/single-templates/single-sidebar-left.php
@@ -13,14 +13,14 @@ defined('ABSPATH') || exit;
 get_header();
 ?>
 
-  <div id="content" class="site-content <?= apply_filters('bootscore/container_class', 'container', 'single-sidebar-left'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-3 pb-5', 'single-sidebar-left'); ?>">
+  <div id="content" class="site-content <?= apply_filters('bootscore/class/container', 'container', 'single-sidebar-left'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-3 pb-5', 'single-sidebar-left'); ?>">
     <div id="primary" class="content-area">
 
       <?php the_breadcrumb(); ?>
 
       <div class="row">
         <?php get_sidebar(); ?>
-        <div class="<?= apply_filters('bootscore/main/col_class', 'col'); ?> order-first order-md-last">
+        <div class="<?= apply_filters('bootscore/class/col/main', 'col'); ?> order-first order-md-last">
 
           <main id="main" class="site-main">
 

--- a/single-templates/single-sidebar-none.php
+++ b/single-templates/single-sidebar-none.php
@@ -13,7 +13,7 @@ defined('ABSPATH') || exit;
 get_header();
 ?>
 
-  <div id="content" class="site-content <?= apply_filters('bootscore/container_class', 'container', 'single-sidebar-none'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-3 pb-5', 'single-sidebar-none'); ?>">
+  <div id="content" class="site-content <?= apply_filters('bootscore/class/container', 'container', 'single-sidebar-none'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-3 pb-5', 'single-sidebar-none'); ?>">
     <div id="primary" class="content-area">
 
       <?php the_breadcrumb(); ?>

--- a/single.php
+++ b/single.php
@@ -12,13 +12,13 @@ defined('ABSPATH') || exit;
 get_header();
 ?>
 
-  <div id="content" class="site-content <?= apply_filters('bootscore/container_class', 'container', 'single'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-3 pb-5', 'single'); ?>">
+  <div id="content" class="site-content <?= apply_filters('bootscore/class/container', 'container', 'single'); ?> <?= apply_filters('bootscore/content/spacer_class', 'pt-3 pb-5', 'single'); ?>">
     <div id="primary" class="content-area">
 
       <?php the_breadcrumb(); ?>
 
       <div class="row">
-        <div class="<?= apply_filters('bootscore/main/col_class', 'col'); ?>">
+        <div class="<?= apply_filters('bootscore/class/col/main', 'col'); ?>">
 
           <main id="main" class="site-main">
 

--- a/template-parts/header/actions-woocommerce.php
+++ b/template-parts/header/actions-woocommerce.php
@@ -18,7 +18,7 @@ defined('ABSPATH') || exit;
 
 <!-- Search toggler -->
 <?php if (is_active_sidebar('top-nav-search')) : ?>
-  <button class="<?= apply_filters('bootscore/header/button_class', 'btn btn-outline-secondary', 'search'); ?> ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
+  <button class="<?= apply_filters('bootscore/class/header_button', 'btn btn-outline-secondary', 'search'); ?> ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
     <i class="fa-solid fa-magnifying-glass"></i><span class="visually-hidden-focusable">Search</span>
   </button>
 <?php endif; ?>
@@ -28,7 +28,7 @@ defined('ABSPATH') || exit;
 if ( is_account_page() ) {
  // Do nothing
 } else { ?>
-  <button class="<?= apply_filters('bootscore/header/button_class', 'btn btn-outline-secondary', 'account'); ?> ms-1 ms-md-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-user" aria-controls="offcanvas-user">
+  <button class="<?= apply_filters('bootscore/class/header_button', 'btn btn-outline-secondary', 'account'); ?> ms-1 ms-md-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-user" aria-controls="offcanvas-user">
     <i class="fa-solid fa-user"></i><span class="visually-hidden-focusable">Account</span>
   </button>
 <?php } ?>
@@ -40,13 +40,13 @@ if ( is_cart() ) {
  // Do nothing
 } elseif ( is_checkout() ) { ?>
   <!-- Add a back-to-cart button -->
-  <a class="<?= apply_filters('bootscore/header/button_class', 'btn btn-outline-secondary', 'return-to-cart'); ?> ms-1 ms-md-2" href="<?= wc_get_cart_url() ?>">
+  <a class="<?= apply_filters('bootscore/class/header_button', 'btn btn-outline-secondary', 'return-to-cart'); ?> ms-1 ms-md-2" href="<?= wc_get_cart_url() ?>">
     <i class="fa-solid fa-arrow-left d-none d-md-inline me-2"></i><i class="fa-solid fa-bag-shopping"></i><span class="visually-hidden-focusable">Return to Cart</span>
   </a>
   <?php 
 } else { ?>
   <!-- Add mini-cart toggler -->
-  <button class="<?= apply_filters('bootscore/header/button_class', 'btn btn-outline-secondary', 'mini-cart'); ?> ms-1 ms-md-2 position-relative" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-cart" aria-controls="offcanvas-cart">
+  <button class="<?= apply_filters('bootscore/class/header_button', 'btn btn-outline-secondary', 'mini-cart'); ?> ms-1 ms-md-2 position-relative" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-cart" aria-controls="offcanvas-cart">
     <i class="fa-solid fa-bag-shopping"></i><span class="visually-hidden-focusable">Cart</span>
     <?php if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
       $count = WC()->cart->cart_contents_count;

--- a/template-parts/header/actions-woocommerce.php
+++ b/template-parts/header/actions-woocommerce.php
@@ -18,7 +18,7 @@ defined('ABSPATH') || exit;
 
 <!-- Search toggler -->
 <?php if (is_active_sidebar('top-nav-search')) : ?>
-  <button class="<?= apply_filters('bootscore/header_button_class', 'btn btn-outline-secondary'); ?> ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
+  <button class="<?= apply_filters('bootscore/header/button_class', 'btn btn-outline-secondary', 'search'); ?> ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
     <i class="fa-solid fa-magnifying-glass"></i><span class="visually-hidden-focusable">Search</span>
   </button>
 <?php endif; ?>
@@ -28,7 +28,7 @@ defined('ABSPATH') || exit;
 if ( is_account_page() ) {
  // Do nothing
 } else { ?>
-  <button class="<?= apply_filters('bootscore/header_button_class', 'btn btn-outline-secondary'); ?> ms-1 ms-md-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-user" aria-controls="offcanvas-user">
+  <button class="<?= apply_filters('bootscore/header/button_class', 'btn btn-outline-secondary', 'account'); ?> ms-1 ms-md-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-user" aria-controls="offcanvas-user">
     <i class="fa-solid fa-user"></i><span class="visually-hidden-focusable">Account</span>
   </button>
 <?php } ?>
@@ -40,13 +40,13 @@ if ( is_cart() ) {
  // Do nothing
 } elseif ( is_checkout() ) { ?>
   <!-- Add a back-to-cart button -->
-  <a class="<?= apply_filters('bootscore/header_button_class', 'btn btn-outline-secondary'); ?> ms-1 ms-md-2" href="<?= wc_get_cart_url() ?>">
+  <a class="<?= apply_filters('bootscore/header/button_class', 'btn btn-outline-secondary', 'return-to-cart'); ?> ms-1 ms-md-2" href="<?= wc_get_cart_url() ?>">
     <i class="fa-solid fa-arrow-left d-none d-md-inline me-2"></i><i class="fa-solid fa-bag-shopping"></i><span class="visually-hidden-focusable">Return to Cart</span>
   </a>
   <?php 
 } else { ?>
   <!-- Add mini-cart toggler -->
-  <button class="<?= apply_filters('bootscore/header_button_class', 'btn btn-outline-secondary'); ?> ms-1 ms-md-2 position-relative" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-cart" aria-controls="offcanvas-cart">
+  <button class="<?= apply_filters('bootscore/header/button_class', 'btn btn-outline-secondary', 'mini-cart'); ?> ms-1 ms-md-2 position-relative" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-cart" aria-controls="offcanvas-cart">
     <i class="fa-solid fa-bag-shopping"></i><span class="visually-hidden-focusable">Cart</span>
     <?php if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
       $count = WC()->cart->cart_contents_count;

--- a/template-parts/header/actions.php
+++ b/template-parts/header/actions.php
@@ -25,7 +25,7 @@ defined('ABSPATH') || exit;
 
 <!-- Search toggler mobile -->
 <?php if (is_active_sidebar('top-nav-search')) : ?>
-  <button class="<?= apply_filters('bootscore/header/button_class', 'btn btn-outline-secondary', 'search'); ?> d-lg-none ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
+  <button class="<?= apply_filters('bootscore/class/header_button', 'btn btn-outline-secondary', 'search'); ?> d-lg-none ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
     <i class="fa-solid fa-magnifying-glass"></i><span class="visually-hidden-focusable">Search</span>
   </button>
 <?php endif; ?>

--- a/template-parts/header/actions.php
+++ b/template-parts/header/actions.php
@@ -25,7 +25,7 @@ defined('ABSPATH') || exit;
 
 <!-- Search toggler mobile -->
 <?php if (is_active_sidebar('top-nav-search')) : ?>
-  <button class="<?= apply_filters('bootscore/header_button_class', 'btn btn-outline-secondary'); ?> d-lg-none ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
+  <button class="<?= apply_filters('bootscore/header/button_class', 'btn btn-outline-secondary', 'search'); ?> d-lg-none ms-1 ms-md-2 top-nav-search-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-search" aria-expanded="false" aria-controls="collapse-search">
     <i class="fa-solid fa-magnifying-glass"></i><span class="visually-hidden-focusable">Search</span>
   </button>
 <?php endif; ?>

--- a/template-parts/header/top-nav-search-collapse-woocommerce.php
+++ b/template-parts/header/top-nav-search-collapse-woocommerce.php
@@ -17,7 +17,7 @@ defined('ABSPATH') || exit;
 <!-- Top Nav Search Collapse -->
 <?php if (is_active_sidebar('top-nav-search')) : ?>
   <div class="collapse bg-body-tertiary position-absolute start-0 end-0" id="collapse-search">
-    <div class="<?= apply_filters('bootscore/container_class', 'container', 'top-nav-search-collapse'); ?> pb-2">
+    <div class="<?= apply_filters('bootscore/class/container', 'container', 'top-nav-search-collapse'); ?> pb-2">
       <?php dynamic_sidebar('top-nav-search'); ?>
     </div>
   </div>

--- a/template-parts/header/top-nav-search-collapse.php
+++ b/template-parts/header/top-nav-search-collapse.php
@@ -17,7 +17,7 @@ defined('ABSPATH') || exit;
 <!-- Top Nav Search Mobile Collapse -->
 <?php if (is_active_sidebar('top-nav-search')) : ?>
   <div class="collapse bg-body-tertiary position-absolute start-0 end-0 d-lg-none" id="collapse-search">
-    <div class="<?= apply_filters('bootscore/container_class', 'container', 'top-nav-search-collapse'); ?> pb-2">
+    <div class="<?= apply_filters('bootscore/class/container', 'container', 'top-nav-search-collapse'); ?> pb-2">
       <?php dynamic_sidebar('top-nav-search'); ?>
     </div>
   </div>

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -20,7 +20,7 @@ defined('ABSPATH') || exit;
 get_header();
 ?>
 
-  <div id="content" class="site-content <?= apply_filters('bootscore/container_class', 'container', 'woocommerce'); ?> <?= apply_filters('bootscore/content/spacer_class', 'py-3', 'woocommerce'); ?>">
+  <div id="content" class="site-content <?= apply_filters('bootscore/class/container', 'container', 'woocommerce'); ?> <?= apply_filters('bootscore/content/spacer_class', 'py-3', 'woocommerce'); ?>">
     <div id="primary" class="content-area">
 
       <main id="main" class="site-main">
@@ -28,7 +28,7 @@ get_header();
         <!-- Breadcrumb -->
         <?php woocommerce_breadcrumb(); ?>
         <div class="row">
-          <div class="<?= apply_filters('bootscore/main/col_class', 'col'); ?>">
+          <div class="<?= apply_filters('bootscore/class/col/main', 'col'); ?>">
             <?php woocommerce_content(); ?>
           </div>
           <!-- sidebar -->


### PR DESCRIPTION
- Renamed `bootscore/header_button_class` to `bootscore/header/button_class` and added which button it is.

I'm also now debating, what would be better filter names?
| Current | Idea |
|--------|--------|
| `bootscore/header_button_class` | `bootscore/class/header_button` | 
| `bootscore/header_class` | `bootscore/class/header` | 
| `bootscore/container_class` | `bootscore/class/container` | 

This idea is coming from the principle of merging things that are alike, like the filter `bootscore/offcanvas/navbar/title`. With the other filters, we do nothing more than managing their classes. So a `bootscore/container/class` would imply more things happening with the container. I'm open to feedback @crftwrk 