### PR TITLE
Enable/disable ajax cart based on Woo settings and added a filter to …

### DIFF
--- a/woocommerce/wc-functions.php
+++ b/woocommerce/wc-functions.php
@@ -44,4 +44,3 @@ function register_ajax_cart() {
   }
 }
 add_action('after_setup_theme', 'register_ajax_cart');
-s

--- a/woocommerce/wc-functions.php
+++ b/woocommerce/wc-functions.php
@@ -33,20 +33,15 @@ require_once('inc/blocks/wc-block-widget-categories.php');
  * Register Ajax Cart
  *
  * Enabled/Disabled based on the setting in backend under WooCommerce > Settings > Products > Enable AJAX add to cart buttons on archives.
- *
- * Allow to edit entire AJAX functionality in child theme using the pluggable function
- * Allow to disable file by filter add_filter('bootscore/load_ajax', '__return_false');
+ * Disable file via filter add_filter('bootscore/load_ajax', '__return_false');
  */
-if (!function_exists('register_ajax_cart')) :
-
-  function register_ajax_cart() {
-    if (apply_filters('bootscore/load_ajax', true)) {
-      $ajax_cart_en = 'yes' === get_option('woocommerce_enable_ajax_add_to_cart');
-      if ($ajax_cart_en) {
-        require_once('inc/ajax-add-to-cart.php');
-      }
+function register_ajax_cart() {
+  if (apply_filters('bootscore/load_ajax', true)) {
+    $ajax_cart_en = 'yes' === get_option('woocommerce_enable_ajax_add_to_cart');
+    if ($ajax_cart_en) {
+      require_once('inc/ajax-add-to-cart.php');
     }
   }
-  add_action('after_setup_theme', 'register_ajax_cart');
-
-endif;
+}
+add_action('after_setup_theme', 'register_ajax_cart');
+s

--- a/woocommerce/wc-functions.php
+++ b/woocommerce/wc-functions.php
@@ -31,14 +31,22 @@ require_once('inc/blocks/wc-block-widget-categories.php');
 
 /**
  * Register Ajax Cart
- * Allow users to edit/disable entire AJAX functionality in child theme
+ *
+ * Enabled/Disabled based on the setting in backend under WooCommerce > Settings > Products > Enable AJAX add to cart buttons on archives.
+ *
+ * Allow to edit entire AJAX functionality in child theme using the pluggable function
+ * Allow to disable file by filter add_filter('bootscore/load_ajax', '__return_false');
  */
 if (!function_exists('register_ajax_cart')) :
 
   function register_ajax_cart() {
-    require_once('inc/ajax-add-to-cart.php');
+    if (apply_filters('bootscore/load_ajax', true)) {
+      $ajax_cart_en = 'yes' === get_option('woocommerce_enable_ajax_add_to_cart');
+      if ($ajax_cart_en) {
+        require_once('inc/ajax-add-to-cart.php');
+      }
+    }
   }
-
   add_action('after_setup_theme', 'register_ajax_cart');
 
 endif;


### PR DESCRIPTION
Enable/disable ajax-add-to-cart.php based on Woo settings:

| Enabled  | Disabled |
| ------------- | ------------- |
| ![Enabled](https://github.com/bootscore/bootscore/assets/51531217/9a8e7070-0054-48af-8310-816f432431ce)  | ![Disabled](https://github.com/bootscore/bootscore/assets/51531217/562f3700-9e57-496e-ae6f-2e87d2c1849b)  |

Disable ajax-add-to-cart.php always, no matter which settings have been made. This brings back the default Woo behaviour, good if you are using the subscription plugin but want to keep the ajax functionality in archives:

```php
add_filter('bootscore/load_ajax', '__return_false');
```

@justinkruit think this is a nice one