### PR TITLE
[Fix] Mini Cart Currency Symbol Position

### DIFF
--- a/woocommerce/cart/mini-cart.php
+++ b/woocommerce/cart/mini-cart.php
@@ -70,7 +70,13 @@ do_action('woocommerce_before_mini_cart'); ?>
                   </a></strong>
               <?php endif; ?>
               <div class="item-quantity">
-                <?php echo wc_get_formatted_cart_item_data($cart_item); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
+                <?php echo wc_get_formatted_cart_item_data($cart_item); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                <?php
+                $currency_symbol           = get_woocommerce_currency_symbol();
+                $display_currency_position = get_option( 'woocommerce_currency_pos' );
+                $quantity_text             = sprintf( '<span class="qty_text">%s</span>', $cart_item['quantity'] );
+                $formatted_price           = sprintf( '%s &times; %s', $quantity_text, $product_price);    
+                $price_with_symbol         = $display_currency_position ? $currency_symbol . ' ' . $formatted_price : $formatted_price . ' ' . $currency_symbol;
                 ?>
                 <?php echo apply_filters('woocommerce_widget_cart_item_quantity', '<span class="quantity">' . sprintf('<span class="qty_text">%s</span> &times; %s', $cart_item['quantity'], $product_price) . '</span>', $cart_item, $cart_item_key); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
                 ?>
@@ -94,7 +100,24 @@ do_action('woocommerce_before_mini_cart'); ?>
               ?>
 
               <div class="bootscore-custom-render-total">
-                <?php echo $cart_item['line_total'].'.00' . get_woocommerce_currency_symbol(); ?>
+              <?php
+              $item_price      = '';
+              $currency_symbol = get_woocommerce_currency_symbol();
+
+              if ($display_currency_position === 'left') {
+                  $item_price = $currency_symbol . $cart_item['line_total'] . '.00';
+              } elseif ( $display_currency_position === 'right' ) {
+                $item_price = $cart_item['line_total'] . '.00' . $currency_symbol;
+              } elseif ($display_currency_position === 'left_space' || $display_currency_position === 'right_space') {
+                $item_price = $cart_item['line_total'] . '.00' . $currency_symbol;
+                if ($display_currency_position === 'left_space') {
+                  $item_price = $currency_symbol . '&nbsp;' . $cart_item['line_total'] . '.00';
+                } elseif ($display_currency_position === 'right_space') {
+                  $item_price = $cart_item['line_total'] . '.00' . '&nbsp;' . $currency_symbol;
+                }
+              }
+              echo $item_price;
+              ?>
               </div>
 
             </div>


### PR DESCRIPTION
Hey @crftwrk,
I have checked this currency position, and it is not updated according to woo-commerce backend settings without product quantity update or added to the cart. I have RnD about it and found a notice in the admin panel. I have checked more than 3/4 industry's top themes which have done the same way to update their quantity. As far as my RnD it's a default behaviour of WooCommerce. 

Please share your thoughts.

![image](https://github.com/bootscore/bootscore/assets/11018986/a2e89e21-7c89-4c3b-80a2-f1ef616ebb72)
