### PR TITLE
Fix double Ajax request for add to cart buttons that are not single_add_to_cart_button

### DIFF
--- a/woocommerce/inc/ajax-add-to-cart.php
+++ b/woocommerce/inc/ajax-add-to-cart.php
@@ -94,6 +94,19 @@ function bootscore_product_page_ajax_add_to_cart_js() {
 
         e.preventDefault();
 
+        // Add a new 'should_send_ajax_request.adding_to_cart' event to prevent standard WooCommerce AJAX request
+        $(document.body).on('should_send_ajax_request.adding_to_cart', function(event, $button) {
+          return false;
+        });
+
+        // Function to add the 'loading' class to the purchase button
+        function addLoadingClass(e, fragments, cart_hash, button) {
+          button.addClass('loading');
+        }
+
+        // Add a new 'ajax_request_not_sent.adding_to_cart' event to trigger addLoadingClass function
+        $(document.body).on('ajax_request_not_sent.adding_to_cart', addLoadingClass);
+
         $('.woocommerce-error, .woocommerce-message, .woocommerce-info').remove();
 
         // Get product name from product-title=""
@@ -131,7 +144,10 @@ function bootscore_product_page_ajax_add_to_cart_js() {
 
           complete: function (response) {
             $thisbutton.addClass('added').removeClass('loading');
-
+            
+            // Remove 'should_send_ajax_request.adding_to_cart' and 'ajax_request_not_sent.adding_to_cart' events
+            $(document.body).off('should_send_ajax_request.adding_to_cart');
+            $(document.body).off('ajax_request_not_sent.adding_to_cart', addLoadingClass);
           },
 
           success: function (response) {


### PR DESCRIPTION
I'm using bootscore for a personal project and I identified some strange behaviors in the add to cart function with Ajax and decided to investigate.

I noticed that when we are not on the product's single page, the Ajax request to add the product to the cart happens twice. One started by WooCommerce's (/plugins/woocommerce/assets/js/frontend/add-to-cart-min.js) file and another started by Bootscore's (/themes/bootscore/woocommerce/inc/ajax-add-to-cart.php) file by the function that starts at Line 93 and ends at Line 173.
It seems that when the request coming from bootscore is completed too early (before the one from WooCommerce), bugs occur such as: The product added to cart notification is removed shortly after being triggered and also duplicate addition of the product to the cart.

Bug reproduction video:
https://github.com/bootscore/bootscore/assets/103291470/005ef88d-24b1-4249-95f0-3dd713dd8932

After that, I thought, "Well, what if I get rid of WooCommerce's default Ajax request, is there a way to achieve this?"

I added define('SCRIPT-DEBUG', true); in wp-config.php to load WooCommerce's (/plugins/woocommerce/assets/js/frontend/add-to-cart.js) file instead of the minified version and started some testing.

Until I saw this code snippet in the AddToCartHandler.prototype.onAddToCart method of the add-to-cart.js file:
`// Allow 3rd parties to validate and quit early.
if ( false === $( document.body ).triggerHandler( 'should_send_ajax_request.adding_to_cart', [ $thisbutton ] ) ) {
  $( document.body ).trigger( 'ajax_request_not_sent.adding_to_cart', [ false, false, $thisbutton ] );
  return true;
}`

I researched a little about it with the help of my friend ChatGPT and saw that it had the potential to do what I needed.

false === $( document.body ).triggerHandler( 'should_send_ajax_request.adding_to_cart', [ $thisbutton ] ) pauses/cancels the WooCommerce standard Ajax add-to-cart request if it returns a false value.

After this, an 'ajax_request_not_sent.adding_to_cart' event is called, which appears to trigger the AddToCartHandler.prototype.updateButton method.

And after some more testing, I came up with code that seems to work well...

Video with the solution:
https://github.com/bootscore/bootscore/assets/103291470/fa007e65-ae34-41e2-9eaa-4b0f8a4a70d1

**Other factors:**
The standard WooCommerce Ajax request loads 3 keys as data: product_sku, product_id and quantity. While the bootscore request only passes the product_id. I don't know if this has any real impact, since on the Store and Product Categories page we don't usually have the option to change the quantity of items.

Also, this is my first Pull Request. I hope I can help in some way. I can't tell if my code is missing something... What I believe I have optimized is the removal of the 'should_send_ajax_request.adding_to_cart' and 'ajax_request_not_sent.adding_to_cart' events right after the completion of each request so that they don't accumulate.

If something is not clear, I am available to explain further.



