### PR TITLE
[FIX] [BUG] Duplicate wc-ajax=add_to_cart

### DIFF
--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -99,6 +99,20 @@ if ( 'no' !== $is_enabled_ajax_cart ) {
 
         $('a.ajax_add_to_cart').on('click', function (e) {
           e.preventDefault();
+
+          // Add new 'should_send_ajax_request.adding_to_cart' event to prevent standard WooCommerce Add To Cart AJAX request
+          $(document.body).on('should_send_ajax_request.adding_to_cart', function(event, $button) {
+            return false;
+          });
+
+          // Function to add the 'loading' class to the a.ajax_add_to_cart button
+          function addLoadingClass(e, fragments, cart_hash, button) {
+            button.addClass('loading');
+          }
+
+          // Add new 'ajax_request_not_sent.adding_to_cart' event to trigger 'addLoadingClass' function
+          $(document.body).on('ajax_request_not_sent.adding_to_cart', addLoadingClass);
+
           $('.woocommerce-error, .woocommerce-message, .woocommerce-info').remove();
           // Get product name from product-title=""
           let prod_title = '';
@@ -130,6 +144,10 @@ if ( 'no' !== $is_enabled_ajax_cart ) {
             data: data,
             complete: function (response) {
               $thisbutton.addClass('added').removeClass('loading');
+
+              // Remove 'should_send_ajax_request.adding_to_cart' and 'ajax_request_not_sent.adding_to_cart' events so they don't accumulate
+              $(document.body).off('should_send_ajax_request.adding_to_cart');
+              $(document.body).off('ajax_request_not_sent.adding_to_cart', addLoadingClass);
             },
             success: function (response) {
               if (response.error & response.product_url) {


### PR DESCRIPTION
Closes https://github.com/bootscore/bootscore/issues/532

I identified some strange behaviors in the add to cart function with AJAX, as also reported in #532  and decided to investigate.

I noticed that when we are not on the product's single page, the AJAX request to add the product to the cart happens twice. One started by WooCommerce's `/plugins/woocommerce/assets/js/frontend/add-to-cart-min.js` file and another started by Bootscore's https://github.com/bootscore/bootscore/blob/v6.0.0-beta1/woocommerce/inc/ajax-cart.php file by the function that starts at line 100 and ends at line 168. It seems that when the request coming from bootscore is completed too early (before the one from WooCommerce), bugs occur such as: The product added to cart notification is removed shortly after being triggered and also duplicate addition of the product to the cart.

### Bug reproduction video:
https://github.com/bootscore/bootscore/assets/103291470/005ef88d-24b1-4249-95f0-3dd713dd8932

After that, I thought, "Well, what if I get rid of WooCommerce's default AJAX request, is there a way to achieve this?"

I added define('SCRIPT-DEBUG', true); in wp-config.php to load WooCommerce's `(/plugins/woocommerce/assets/js/frontend/add-to-cart.js)` file instead of the minified version and started some testing.

Until I saw this code snippet in the `AddToCartHandler.prototype.onAddToCart` method of the add-to-cart.js file:
`// Allow 3rd parties to validate and quit early. if ( false === $( document.body ).triggerHandler( 'should_send_ajax_request.adding_to_cart', [ $thisbutton ] ) ) { $( document.body ).trigger( 'ajax_request_not_sent.adding_to_cart', [ false, false, $thisbutton ] ); return true;
}`

I researched a little about it with the help of my friend ChatGPT and saw that it had the potential to do what I needed.

`false === $( document.body ).triggerHandler( 'should_send_ajax_request.adding_to_cart', [ $thisbutton ] )` pauses/cancels the WooCommerce standard AJAX add-to-cart request if it returns a false value.

After this, an `'ajax_request_not_sent.adding_to_cart'` event is called, which appears to trigger the `AddToCartHandler.prototype.updateButton` method. I used this same `'ajax_request_not_sent.adding_to_cart'` to trigger an `addLoadingClass` function to return the 'loading' class removed by the `AddToCartHandler.prototype.updateButton` method.

And after some more testing, I came up with code that seems to work well...

### Video with the solution:
https://github.com/bootscore/bootscore/assets/103291470/fa007e65-ae34-41e2-9eaa-4b0f8a4a70d1

I made some changes to the code comments in the video, but that's it.

### Other factors:
The standard WooCommerce Ajax request loads 3 keys as data: product_sku, product_id and quantity. While the bootscore request only passes the product_id. I don't know if this has any real impact, since on the Store and Product Categories page we don't usually have the option to change the quantity of items.

