### PR TITLE
Skip cart page

### DIFF
--- a/woocommerce/inc/wc-cart.php
+++ b/woocommerce/inc/wc-cart.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * WooCommerce Enabled Cart Page
+ *
+ * @package Bootscore 
+ * @version 6.0.0
+ */
+
+
+// Exit if accessed directly
+defined('ABSPATH') || exit;
+
+
+/**
+ * Add class to WooCommerce Mini-Cart "View Cart" and Checkout" buttons
+ */
+remove_action('woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_button_view_cart', 10);
+add_action('woocommerce_widget_shopping_cart_buttons', 'bootscore_widget_shopping_cart_button_view_cart', 10);
+
+function bootscore_widget_shopping_cart_button_view_cart() {
+  echo '<a href="' . esc_url(wc_get_cart_url()) . '" class="btn btn-secondary d-block mb-2">' . esc_html__('View cart', 'woocommerce') . '</a>';
+}
+
+remove_action('woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_proceed_to_checkout', 20);
+add_action('woocommerce_widget_shopping_cart_buttons', 'bootscore_widget_shopping_cart_proceed_to_checkout', 20);
+
+function bootscore_widget_shopping_cart_proceed_to_checkout() {
+  echo '<a href="' . esc_url(wc_get_checkout_url()) . '" class="btn btn-primary d-block">' . esc_html__('Checkout', 'woocommerce') . '</a>';
+}

--- a/woocommerce/inc/wc-mini-cart.php
+++ b/woocommerce/inc/wc-mini-cart.php
@@ -35,20 +35,3 @@ if (!function_exists('bootscore_mini_cart')) :
   add_filter('woocommerce_add_to_cart_fragments', 'bootscore_mini_cart');
 
 endif;
-
-
-/**
- * Mini cart widget buttons
- */
-remove_action('woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_button_view_cart', 10);
-remove_action('woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_proceed_to_checkout', 20);
-add_action('woocommerce_widget_shopping_cart_buttons', 'bootscore_widget_shopping_cart_button_view_cart', 10);
-add_action('woocommerce_widget_shopping_cart_buttons', 'bootscore_widget_shopping_cart_proceed_to_checkout', 20);
-
-function bootscore_widget_shopping_cart_button_view_cart() {
-  echo '<a href="' . esc_url(wc_get_cart_url()) . '" class="btn btn-secondary d-block mb-2">' . esc_html__('View cart', 'woocommerce') . '</a>';
-}
-
-function bootscore_widget_shopping_cart_proceed_to_checkout() {
-  echo '<a href="' . esc_url(wc_get_checkout_url()) . '" class="btn btn-primary d-block">' . esc_html__('Checkout', 'woocommerce') . '</a>';
-}

--- a/woocommerce/inc/wc-skip-cart.php
+++ b/woocommerce/inc/wc-skip-cart.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * WooCommerce Skip Cart Page
+ *
+ * @package Bootscore 
+ * @version 6.0.0
+ */
+
+
+// Exit if accessed directly
+defined('ABSPATH') || exit;
+
+
+
+/**
+ * Mini cart widget buttons
+ */
+remove_action('woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_proceed_to_checkout', 20);
+add_action('woocommerce_widget_shopping_cart_buttons', 'bootscore_widget_shopping_cart_proceed_to_checkout', 20);
+
+function bootscore_widget_shopping_cart_proceed_to_checkout() {
+  echo '<a href="' . esc_url(wc_get_checkout_url()) . '" class="btn btn-primary btn-lg d-block">' . esc_html__('Checkout', 'woocommerce') . '</a>';
+}
+
+
+/**
+ * Hide WooCommerce Mini-Cart "View Cart" Button
+ */
+remove_action('woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_button_view_cart', 10);
+add_action('woocommerce_widget_shopping_cart_buttons', 'bootscore_remove_view_cart_minicart', 10);
+ 
+function bootscore_remove_view_cart_minicart() {
+  remove_action( 'woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_button_view_cart', 20 );
+}
+
+
+/**
+ * Skip cart redirecting to checkout
+ */
+function bootscore_skip_cart_page_redirection_to_checkout() {
+
+  // If is cart page, redirect checkout.
+  if( is_cart() )
+    wp_redirect( wc_get_checkout_url() );
+}
+add_action('template_redirect', 'bootscore_skip_cart_page_redirection_to_checkout');

--- a/woocommerce/wc-functions.php
+++ b/woocommerce/wc-functions.php
@@ -33,7 +33,8 @@ require_once('inc/blocks/wc-block-widget-categories.php');
  * Register Ajax Cart
  *
  * Enabled/Disabled based on the setting in backend under WooCommerce > Settings > Products > Enable AJAX add to cart buttons on archives.
- * Disable file via filter add_filter('bootscore/load_ajax_cart', '__return_false');
+ * Disable file via filter 
+ * add_filter('bootscore/load_ajax_cart', '__return_false');
  */
 function bootscore_register_ajax_cart() {
   if (apply_filters('bootscore/load_ajax_cart', true)) {
@@ -44,3 +45,22 @@ function bootscore_register_ajax_cart() {
   }
 }
 add_action('after_setup_theme', 'bootscore_register_ajax_cart');
+
+
+/**
+ * Skip cart page
+ *
+ * Disable cart page, "View Cart" button in mini-cart and redirect cart page to checkout
+ *
+ * Enable default cart page and buttoins via filter 
+ * add_filter('bootscore/skip_cart', '__return_false');
+ */
+function bootscore_register_cart_file() {
+  if (apply_filters('bootscore/skip_cart', true)) {
+    require_once('inc/wc-skip-cart.php');
+  } else {
+    require_once('inc/wc-cart.php');
+  }
+}
+add_action('after_setup_theme', 'bootscore_register_cart_file');
+


### PR DESCRIPTION
This is an idea for later. Because the new AJAX cart is a full working one now, we can hide the "View cart" button, skip the entire cart page and redirect to checkout

Use a filter to restore default cart and button:

```php
/**
 * Disable skip cart and enable the cart page
 */
add_filter('bootscore/skip_cart', '__return_false');
```