### PR TITLE
Fix path to SCSS source map

### DIFF
--- a/inc/scss-compiler.php
+++ b/inc/scss-compiler.php
@@ -114,10 +114,13 @@ class BootscoreScssCompiler {
 
   private function setOutputStyle() {
     if ($this->is_environment_dev) {
+      $source_map_url = site_url('', 'relative') . '/' . ltrim(str_replace(ABSPATH, '', $this->getCssFile()), '/');
+      $source_map_url .= '.map';
+
       $this->compiler->setSourceMap(Compiler::SOURCE_MAP_FILE);
       $this->compiler->setSourceMapOptions([
-        'sourceMapURL'      => site_url('', 'relative') . '/' . str_replace(ABSPATH, '', $this->css_file) . '.map',
-        'sourceMapBasepath' => substr(str_replace('\\', '/', ABSPATH), 0, - 1),
+        'sourceMapURL'      => $source_map_url,
+        'sourceMapBasepath' => rtrim(str_replace('\\', '/', ABSPATH), '/'),
         'sourceRoot'        => site_url('', 'relative') . '/',
       ]);
       $this->compiler->setOutputStyle(\ScssPhp\ScssPhp\OutputStyle::EXPANDED);


### PR DESCRIPTION
Closes https://github.com/bootscore/bootscore/issues/805

https://github.com/bootscore/bootscore/pull/802 breaks the path to the `main.css.map` in compiled `main.css` if site is under development. This PR fixes that.

Add `define('WP_ENVIRONMENT_TYPE', 'development');` to `wp-config.php` and inspect frontend styles.

@justinkruit quickly tried to fix that by myself, let me know if this is correct what I'm done.