### PR TITLE
Fix redirect checkout if cart is empty

### DIFF
--- a/woocommerce/inc/wc-skip-cart.php
+++ b/woocommerce/inc/wc-skip-cart.php
@@ -4,7 +4,7 @@
  * WooCommerce Skip Cart Page
  *
  * @package Bootscore 
- * @version 6.0.0
+ * @version 6.0.1
  */
 
 

--- a/woocommerce/inc/wc-skip-cart.php
+++ b/woocommerce/inc/wc-skip-cart.php
@@ -31,11 +31,20 @@ remove_action('woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_sh
 
 
 /**
- * Skip cart page and redirecting to checkout
+ * Skip cart page and redirecting to checkout.
+ * Redirect empty checkout to shop page.
  */
 function bootscore_skip_cart_page_redirection_to_checkout() {
+  // Check if we are on the cart page and redirect to the checkout page
+  if (is_cart()) {
+    wp_redirect(wc_get_checkout_url());
+    exit;
+  }
 
-  if( is_cart() )
-    wp_redirect( wc_get_checkout_url() );
+  // Check if we are on the checkout page and if the cart is empty, redirect to the shop page
+  if (is_checkout() && WC()->cart->is_empty()) {
+    wp_redirect(wc_get_page_permalink('shop'));
+    exit;
+  }
 }
 add_action('template_redirect', 'bootscore_skip_cart_page_redirection_to_checkout');


### PR DESCRIPTION
This fixes a bug that has been overlooked in https://github.com/bootscore/bootscore/pull/755. In my point of view this is an edge case and can be solved in the next maintaining release. This bug happens if you are on checkout page and do nothing more a few days until WC empties the cart by itself by removing the cookie.

Steps to reproduce: 

- Open https://dev.bootscore.me/shop/ twice in two tabs
- Add a product and go to checkout
- Switch to the other tab and remove product from the cart
- Go back to the checkout tab and reload the page

As a result, page stucks because checkout, if cart is empty, redirects to cart page by WC and cart page redirects to checkout by us.

This PR checks if cart is empty and redirects checkout to shop page instead.