### PR TITLE
Fix: Empty `Home` value in WC breadcrumb

### DIFF
--- a/assets/scss/bootscore-woocommerce/_wc-breadcrumb.scss
+++ b/assets/scss/bootscore-woocommerce/_wc-breadcrumb.scss
@@ -3,7 +3,7 @@ WooCommerce Breadcrumb
 --------------------------------------------------------------*/
 
 .wc-breadcrumb {
-
+  /*
   // Add a Fontawesome house icon for empty "Home" (wc-functions.php)
   .breadcrumb-item:first-child a {
 
@@ -24,7 +24,29 @@ WooCommerce Breadcrumb
     &:hover::before {
       background-color: var(--#{$prefix}link-hover-color);
     }
+  }*/
+
+  .breadcrumb-item:first-child a {
+
+    position: relative;
+    text-indent: -9999px;
+    display: block;
+    margin-right: $breadcrumb-item-padding-x;
+
+
+    &::after {
+
+      content: "x";
+      text-indent: 0;
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
   }
+
+
+
+
 
   // Additional code for wc breadcrumbs, 
   // as the wc breadcrumb function does not allow for custom 

--- a/assets/scss/bootscore-woocommerce/_wc-breadcrumb.scss
+++ b/assets/scss/bootscore-woocommerce/_wc-breadcrumb.scss
@@ -3,13 +3,18 @@ WooCommerce Breadcrumb
 --------------------------------------------------------------*/
 
 .wc-breadcrumb {
-  /*
-  // Add a Fontawesome house icon for empty "Home" (wc-functions.php)
-  .breadcrumb-item:first-child a {
 
-    &::before {
-      content: ' ';
-      display: inline-block;
+  // Add a Fontawesome house icon
+  .breadcrumb-item:first-child a {
+    position: relative;
+    text-indent: -9999px;
+    display: inline-block;
+    padding-right: $breadcrumb-item-padding-x *2;
+
+    &::after {
+      content: '';
+      position: absolute;
+      left: 0;
       width: $font-size-base;
       height: 100%;
       background-color: var(--#{$prefix}link-color);
@@ -21,32 +26,10 @@ WooCommerce Breadcrumb
       -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' height='1em' viewBox='0 0 576 512'%3e%3c!--! Font Awesome Free 6.4.0 by %40fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons%2c Inc. --%3e%3cpath d='M575.8 255.5c0 18-15 32.1-32 32.1h-32l.7 160.2c0 2.7-.2 5.4-.5 8.1V472c0 22.1-17.9 40-40 40H456c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1H416 392c-22.1 0-40-17.9-40-40V448 384c0-17.7-14.3-32-32-32H256c-17.7 0-32 14.3-32 32v64 24c0 22.1-17.9 40-40 40H160 128.1c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2H104c-22.1 0-40-17.9-40-40V360c0-.9 0-1.9 .1-2.8V287.6H32c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z'/%3e%3c/svg%3e");
     }
 
-    &:hover::before {
+    &:hover::after {
       background-color: var(--#{$prefix}link-hover-color);
     }
-  }*/
-
-  .breadcrumb-item:first-child a {
-
-    position: relative;
-    text-indent: -9999px;
-    display: block;
-    margin-right: $breadcrumb-item-padding-x;
-
-
-    &::after {
-
-      content: "x";
-      text-indent: 0;
-      position: absolute;
-      top: 0;
-      left: 0;
-    }
   }
-
-
-
-
 
   // Additional code for wc breadcrumbs, 
   // as the wc breadcrumb function does not allow for custom 

--- a/assets/scss/bootscore-woocommerce/_wc-breadcrumb.scss
+++ b/assets/scss/bootscore-woocommerce/_wc-breadcrumb.scss
@@ -4,13 +4,15 @@ WooCommerce Breadcrumb
 
 .wc-breadcrumb {
 
-  // Add a Fontawesome house icon
+  // Move `Home` out of the screen instead using empty value
+  // See https://github.com/orgs/bootscore/discussions/775
   .breadcrumb-item:first-child a {
     position: relative;
     text-indent: -9999px;
     display: inline-block;
     padding-right: $breadcrumb-item-padding-x *2;
 
+    // Add Fontawesome house icon
     &::after {
       content: '';
       position: absolute;

--- a/woocommerce/inc/wc-breadcrumb.php
+++ b/woocommerce/inc/wc-breadcrumb.php
@@ -26,9 +26,7 @@ if (!function_exists('bs_woocommerce_breadcrumbs')) :
       </nav>',
       'before'      => '<li class="breadcrumb-item">',
       'after'       => '</li>',
-      // Remove "Home" and add Fontawesome house icon (_wc_breadcrumb.scss)
-      //'home'        => _x('Home', 'breadcrumb', 'woocommerce'),
-      'home'        => ' ',
+      'home'        => _x('Home', 'breadcrumb', 'woocommerce'),
     );
   }
 endif;

--- a/woocommerce/inc/wc-breadcrumb.php
+++ b/woocommerce/inc/wc-breadcrumb.php
@@ -4,7 +4,7 @@
  * WooCommerce Breadcrumb
  *
  * @package Bootscore 
- * @version 6.0.0
+ * @version 6.0.1
  */
 
 


### PR DESCRIPTION
This PR brings back the `Home` to WC breadcrumb, because as discussed in https://github.com/orgs/bootscore/discussions/775, the `Home` value of Breadcrumb is recognized as empty by Google so far.

Unfortunately, it's not possible to add the icon with a filter, because WC escapes the HTML and overriding WC's `breadcrumb.php` template is not an option anymore https://github.com/bootscore/bootscore/issues/333.

As a workaround `text-indent` is used to move the word `Home` out of the screen (but visible for Google) and adds the home icon as a `mask-image` pseudo class like done before. There are no visual changes in the frontend.

cc @stan1781 