### PR TITLE
Fix: Compile error using woocommerce css

### DIFF
--- a/assets/scss/bootscore-woocommerce/_wc-qty-btn.scss
+++ b/assets/scss/bootscore-woocommerce/_wc-qty-btn.scss
@@ -22,19 +22,6 @@ WooCommerce Quantity Input
       margin: 0;
     }
   }
-
-  // Disable quantity input if only 1 product in stock left or sold individually
-  &:has([max="1"]) {
-
-    .input-group-text {
-      pointer-events: none;
-    }
-
-    .form-control {
-      background-color: $input-disabled-bg;
-      pointer-events: none;
-    }
-  }
 }
 
 

--- a/assets/scss/bootscore-woocommerce/_wc-qty-btn.scss
+++ b/assets/scss/bootscore-woocommerce/_wc-qty-btn.scss
@@ -21,12 +21,12 @@ WooCommerce Quantity Input
       display: none;
       margin: 0;
     }
-    
+/*
     // Disable quantity input if only 1 product in stock left or sold individually
     &[max="1"] {
       background-color: $input-disabled-bg;
       pointer-events: none;
-    }
+    }*/
   }
 }
 

--- a/assets/scss/bootscore-woocommerce/_wc-qty-btn.scss
+++ b/assets/scss/bootscore-woocommerce/_wc-qty-btn.scss
@@ -22,6 +22,19 @@ WooCommerce Quantity Input
       margin: 0;
     }
   }
+
+  // Disable quantity input if only 1 product in stock left or sold individually
+  &:has([max="1"]) {
+
+    .input-group-text {
+      pointer-events: none;
+    }
+
+    .form-control {
+      background-color: $input-disabled-bg;
+      pointer-events: none;
+    }
+  }
 }
 
 

--- a/assets/scss/bootscore-woocommerce/_wc-qty-btn.scss
+++ b/assets/scss/bootscore-woocommerce/_wc-qty-btn.scss
@@ -21,16 +21,9 @@ WooCommerce Quantity Input
       display: none;
       margin: 0;
     }
-  }
-
-  // Disable quantity input if only 1 product in stock left or sold individually
-  &:has([max="1"]) {
-
-    .input-group-text {
-      pointer-events: none;
-    }
-
-    .form-control {
+    
+    // Disable quantity input if only 1 product in stock left or sold individually
+    &[max="1"] {
       background-color: $input-disabled-bg;
       pointer-events: none;
     }

--- a/assets/scss/bootscore-woocommerce/_wc-qty-btn.scss
+++ b/assets/scss/bootscore-woocommerce/_wc-qty-btn.scss
@@ -21,13 +21,24 @@ WooCommerce Quantity Input
       display: none;
       margin: 0;
     }
-/*
-    // Disable quantity input if only 1 product in stock left or sold individually
-    &[max="1"] {
+  }
+
+  /*
+  // Disable quantity input if only 1 product in stock left or sold individually
+  // https://github.com/bootscore/bootscore/issues/801
+  // https://github.com/bootscore/bootscore/pull/823
+  &:has([max="1"]) {
+
+    .input-group-text {
+      pointer-events: none;
+    }
+
+    .form-control {
       background-color: $input-disabled-bg;
       pointer-events: none;
-    }*/
+    }
   }
+  */
 }
 
 

--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -606,12 +606,12 @@ function add_minicart_quantity_fields($html, $cart_item, $cart_item_key) {
 
 
 /**
- * Disable quantity buttons if product is sold individually or only one in stock left
+ * Disable quantity input if only 1 product in stock left or sold individually
  *
- * See https://github.com/bootscore/bootscore/issues/801
- * See https://github.com/bootscore/bootscore/pull/823
+ * https://github.com/bootscore/bootscore/issues/801
+ * https://github.com/bootscore/bootscore/pull/823
  */
-function add_custom_quantity_disable_script() {
+function bootscore_disable_quantity() {
   ?>
   <script>
   jQuery(function ($) {
@@ -640,5 +640,4 @@ function add_custom_quantity_disable_script() {
   <?php
 }
 
-// Hook the function to wp_footer to ensure it loads on the front-end
-add_action('wp_footer', 'add_custom_quantity_disable_script');
+add_action('wp_footer', 'bootscore_disable_quantity');

--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -621,7 +621,7 @@ function bootscore_disable_quantity() {
         var $input = $(this).find('input[type="number"]');
         var max = $input.attr('max');
 
-        if (max == 1) { // Check if max is 1 or any condition you wish
+        if (max == 1) { // Check if max is 1
           $(this).find('button').attr('disabled', 'disabled');
           $input.attr('disabled', 'disabled');
         }

--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -603,3 +603,42 @@ function add_minicart_quantity_fields($html, $cart_item, $cart_item_key) {
 
   return $output;
 }
+
+
+/**
+ * Disable quantity buttons if product is sold individually or only one in stock left
+ *
+ * See https://github.com/bootscore/bootscore/issues/801
+ * See https://github.com/bootscore/bootscore/pull/823
+ */
+function add_custom_quantity_disable_script() {
+  ?>
+  <script>
+  jQuery(function ($) {
+    // Function to disable quantity inputs and buttons
+    function disableQuantityInputs() {
+      $('.quantity').each(function() {
+        var $input = $(this).find('input[type="number"]');
+        var max = $input.attr('max');
+
+        if (max == 1) { // Check if max is 1 or any condition you wish
+          $(this).find('button').attr('disabled', 'disabled');
+          $input.attr('disabled', 'disabled');
+        }
+      });
+    }
+
+    // Trigger the function after AJAX completes
+    $(document).ajaxComplete(function() {
+      disableQuantityInputs();
+    });
+
+    // Optionally, call it on document ready to handle initial load cases
+    disableQuantityInputs();
+  });
+  </script>
+  <?php
+}
+
+// Hook the function to wp_footer to ensure it loads on the front-end
+add_action('wp_footer', 'add_custom_quantity_disable_script');

--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -4,7 +4,7 @@
  * WooCommerce AJAX cart
  *
  * @package Bootscore
- * @version 6.0.0
+ * @version 6.0.1
  */
 
 
@@ -576,6 +576,7 @@ function bootscore_qty_update(){
 }
 
 // Add quantity fields in Mini Cart.
+// Edit this snippet
 add_filter('woocommerce_widget_cart_item_quantity', 'add_minicart_quantity_fields', 10, 3);
 function add_minicart_quantity_fields($html, $cart_item, $cart_item_key) {
   $_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );

--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -4,7 +4,7 @@
  * WooCommerce AJAX cart
  *
  * @package Bootscore
- * @version 6.0.1
+ * @version 6.0.0
  */
 
 
@@ -576,7 +576,6 @@ function bootscore_qty_update(){
 }
 
 // Add quantity fields in Mini Cart.
-// Edit this snippet
 add_filter('woocommerce_widget_cart_item_quantity', 'add_minicart_quantity_fields', 10, 3);
 function add_minicart_quantity_fields($html, $cart_item, $cart_item_key) {
   $_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );

--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -4,7 +4,7 @@
  * WooCommerce AJAX cart
  *
  * @package Bootscore
- * @version 6.0.0
+ * @version 6.0.1
  */
 
 


### PR DESCRIPTION
Closes https://github.com/bootscore/bootscore/issues/801

I solved this now using jQuery to get rid of the SCSS selector. It's not an elegant way, but it works and I think this is just temporary and we can revert this PR when scssphp v2 has fixed this. For this reason, the scss snippet is just commented out.

Go to https://dev.bootscore.me/product/beanie/, add product to the cart and check quantity input and buttons in offcanvas cart. Input and buttons are disabled, because this product has quantity `max="1"` attribute.

Edit: check https://github.com/bootscore/bootscore/pull/827