### PR TITLE
Footer 4 "widget" class assigned to wrong element

### DIFF
--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -126,9 +126,9 @@ if (!function_exists('bootscore_widgets_init')) :
       'name'          => esc_html__('Footer 4', 'bootscore'),
       'id'            => 'footer-4',
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
-      'before_widget' => '<div class="footer_widget mb-3">',
+      'before_widget' => '<div class="widget footer_widget mb-3">',
       'after_widget'  => '</div>',
-      'before_title'  => '<h2 class="widget widget-title h5">',
+      'before_title'  => '<h2 class="widget-title h5">',
       'after_title'   => '</h2>'
     ));
 

--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -6,7 +6,7 @@
  * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
  *
  * @package Bootscore 
- * @version 6.0.0
+ * @version 6.0.2
  */
 
 


### PR DESCRIPTION
Moved the "widget" class from the `<h2> ` tag to the parent `<div>`  in Footer 4 widget area