### PR TITLE
remove ajax cart from initial page load

### DIFF
--- a/template-parts/header/actions-woocommerce.php
+++ b/template-parts/header/actions-woocommerce.php
@@ -61,12 +61,13 @@ if ( is_cart() ) {
     <div class="d-inline-flex align-items-center">
       <i class="fa-solid fa-bag-shopping"></i><span class="visually-hidden-focusable">Cart</span>
       <?php if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
-        $count = WC()->cart->cart_contents_count;
+        //$count = WC()->cart->cart_contents_count;
         ?>
         <span class="cart-content">
+        <?php /**
           <?php if ($count > 0) { ?>
             <?= esc_html($count); ?>
-          <?php } ?>
+          <?php } ?> */ ?>
         </span>
       <?php } ?>
     </div>

--- a/template-parts/header/offcanvas-woocommerce.php
+++ b/template-parts/header/offcanvas-woocommerce.php
@@ -46,7 +46,7 @@ if ( is_checkout() || is_cart() ) {
     </div>
     <div class="offcanvas-body p-0">
       <div class="cart-list">
-        <div class="widget_shopping_cart_content"><?php woocommerce_mini_cart(); ?></div>
+        <div class="widget_shopping_cart_content"><?php //woocommerce_mini_cart(); ?></div>
       </div>
     </div>
   </div>

--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -406,7 +406,7 @@ function bootscore_ajax_add_to_cart_js() {
             }, 300);
 
             let cart_res = res.data;
-            $('.cart-content span.woocommerce-Price-amount.amount').html(
+            $('#offcanvas-cart .cart-content span.woocommerce-Price-amount.amount').html(
               cart_res['total']
             );
             wrap.find('.bootscore-custom-render-total').html(
@@ -418,7 +418,7 @@ function bootscore_ajax_add_to_cart_js() {
               cart_res['total']
             );
             $('.cart-footer .amount').html(cart_res['total']);
-            $('.cart-content .cart-total').html(cart_res['total']);
+            //$('.cart-content .cart-total').html(cart_res['total']);
           },
           error: function (jqXHR, textStatus, errorThrown) {
             setTimeout(function () {

--- a/woocommerce/inc/wc-mini-cart.php
+++ b/woocommerce/inc/wc-mini-cart.php
@@ -22,7 +22,7 @@ if (!function_exists('bootscore_mini_cart')) :
     $count = WC()->cart->cart_contents_count; ?>
     <span class="cart-content">
       <?php if ($count > 0) { ?>
-        <span class="cart-content-count position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"><?= esc_html($count); ?></span><span class="cart-total ms-2 d-none d-md-inline"><?= WC()->cart->get_cart_subtotal(); ?></span>
+        <span class="cart-content-count position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"><?= esc_html($count); ?></span>
       <?php } ?>
     </span>
 


### PR DESCRIPTION
Ajax cart was loaded in the html response as well as directly after the DOM is ready. So now the initial html repsonse should be cachable.

The "only" drawback is that to "prevent" flickering of the cart button (resizes when the total amount of the cart is set) I had to remove the display of the cart total from the cart button in the header.

I assume next time I should just delete the commented parts?