### PR TITLE
Update WC 9.5 templates

### DIFF
--- a/assets/scss/bootscore-woocommerce/_wc-product-variable.scss
+++ b/assets/scss/bootscore-woocommerce/_wc-product-variable.scss
@@ -4,10 +4,17 @@ WooCommerce Variable Product
 
 // Variations select
 .woocommerce div.product form.cart .variations {
-  margin-bottom: 0;
 
   select {
     margin-right: 0;
+  }
+
+  // Fix the clear button (WC 9.5) 
+  .reset_variations {
+    border: none;
+    background: none;
+    padding: 0;
+    color: var(--#{$prefix}link-color);
   }
 }
 

--- a/woocommerce/cart/mini-cart.php
+++ b/woocommerce/cart/mini-cart.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Mini-cart
  *
@@ -15,14 +14,14 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.3.0
+ * @version 9.4.0
  */
 
 defined('ABSPATH') || exit;
 
 do_action('woocommerce_before_mini_cart'); ?>
 
-<?php if (!WC()->cart->is_empty()) : ?>
+<?php if ( WC()->cart && ! WC()->cart->is_empty() ) : ?>
 
   <div class="woocommerce-mini-cart cart_list product_list_widget list-group list-group-flush <?php echo esc_attr($args['list_class']); ?>">
     <?php


### PR DESCRIPTION
- Update: `mini-cart.php` (WC 9.5)
- Fix: Table and clear button in variable product page (WC 9.5 changes the `<a>` to `<button>` element)


| Before  | After |
| ------------- | ------------- |
| <img width="411" alt="before-1" src="https://github.com/user-attachments/assets/349acfba-7308-4a08-a31c-def4feb09f70">  | <img width="407" alt="after-1" src="https://github.com/user-attachments/assets/1c1313a0-e9a8-40eb-a0fe-579e252fe6a4">  |
| <img width="411" alt="before-2" src="https://github.com/user-attachments/assets/90313026-d6bf-4afd-8520-fd398ebd45a4">  | <img width="405" alt="after-2" src="https://github.com/user-attachments/assets/ade30f57-66c1-4785-af53-a2e06721d907">  |







