### PR TITLE
Add filters to enhance WooCommerce header and offcanvas user account 

### DIFF
--- a/template-parts/header/actions-woocommerce.php
+++ b/template-parts/header/actions-woocommerce.php
@@ -25,13 +25,17 @@ defined('ABSPATH') || exit;
 
 <!-- User toggler -->
 <?php
-if ( is_account_page() || is_checkout() ) {
- // Do nothing
-} else { ?>
-  <button class="<?= apply_filters('bootscore/class/header/button', 'btn btn-outline-secondary', 'account-toggler'); ?> <?= apply_filters('bootscore/class/header/action/spacer', 'ms-1 ms-md-2', 'account-toggler'); ?> account-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-user" aria-controls="offcanvas-user">
-    <?= apply_filters('bootscore/icon/user', '<i class="fa-solid fa-user"></i>'); ?> <span class="visually-hidden-focusable">Account</span>
-  </button>
-<?php } ?>
+if (apply_filters('bootscore/enable_account', true)) {
+  if ( is_account_page() || is_checkout() ) {
+  // Do nothing
+  } else { ?>
+    <button class="<?= apply_filters('bootscore/class/header/button', 'btn btn-outline-secondary', 'account-toggler'); ?> <?= apply_filters('bootscore/class/header/action/spacer', 'ms-1 ms-md-2', 'account-toggler'); ?> account-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-user" aria-controls="offcanvas-user">
+      <?= apply_filters('bootscore/icon/user', '<i class="fa-solid fa-user"></i>'); ?> <span class="visually-hidden-focusable">Account</span>
+    </button>
+  <?php } 
+ }
+?>
+
 
 
 <!-- Mini cart toggler -->

--- a/template-parts/header/offcanvas-woocommerce.php
+++ b/template-parts/header/offcanvas-woocommerce.php
@@ -6,7 +6,7 @@
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *
  * @package Bootscore
- * @version 6.0.0
+ * @version 6.1.0
  */
 
 
@@ -18,21 +18,24 @@ defined('ABSPATH') || exit;
 
 <!-- Offcanvas user -->
 <?php
-if ( is_account_page() || is_checkout() ) {
- // Do nothing
-} else { ?>
-<div class="offcanvas offcanvas-<?= apply_filters('bootscore/class/header/offcanvas/direction', 'end', 'account'); ?>" tabindex="-1" id="offcanvas-user">
-  <div class="offcanvas-header">
-    <span class="h5 offcanvas-title"><?= apply_filters('bootscore/offcanvas/user/title', __('Account', 'bootscore')); ?></span>
-    <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
-  </div>
-  <div class="offcanvas-body">
-    <div class="my-offcanvas-account">
-      <?= do_shortcode('[woocommerce_my_account]'); ?>
+if (apply_filters('bootscore/enable_account', true)) {
+  if ( is_account_page() || is_checkout() ) {
+  // Do nothing
+  } else { ?>
+  <div class="offcanvas offcanvas-<?= apply_filters('bootscore/class/header/offcanvas/direction', 'end', 'account'); ?>" tabindex="-1" id="offcanvas-user">
+    <div class="offcanvas-header">
+      <span class="h5 offcanvas-title"><?= apply_filters('bootscore/offcanvas/user/title', __('Account', 'bootscore')); ?></span>
+      <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body">
+      <div class="my-offcanvas-account">
+        <?= do_shortcode('[woocommerce_my_account]'); ?>
+      </div>
     </div>
   </div>
-</div>
-<?php } ?>
+  <?php }
+  }
+?>
 
 <!-- Offcanvas cart -->
 <?php


### PR DESCRIPTION
This pull request introduces a new filter 'bootscore/enable_account' that, when applied, will hide the user account button and the associated offcanvas flyout. 

This is especially useful for WooCommerce sites that are designed to be anonymous guest-only transactional sites, where displaying account options is unnecessary.


Key Changes:

Added a new filter ensures that the user account UI elements are not displayed, making the site more suited for anonymous transactions.

This change was discussed and referenced in a [GitHub discussion](https://github.com/orgs/bootscore/discussions/880)

Testing
After applying the filter

```
/**
 * Disable WooCommerce account
 */
add_filter('bootscore/enable_account', '__return_false');
```
the user account button and the offcanvas components are be removed from the site’s UI.  Upon inspecting the page source, you will find no references to the offcanvas user controls.

