### PR TITLE
Minor SCSS fixes

### DIFF
--- a/assets/scss/bootscore/blocks/_blocks.scss
+++ b/assets/scss/bootscore/blocks/_blocks.scss
@@ -14,9 +14,28 @@ Block Widgets
 }
 
 
-// Add rounded to block img if class added to img block
-figure.rounded img {
-  border-radius: var(--#{$prefix}border-radius);
+// Add rounded-* classes to block img when class is added to the figure
+figure.rounded {
+
+  img {
+    border-radius: var(--#{$prefix}border-radius);
+  }
+
+  &-lg img {
+    border-radius: var(--#{$prefix}border-radius-lg);
+  }
+
+  &-xl img {
+    border-radius: var(--#{$prefix}border-radius-xl);
+  }
+
+  &-xxl img {
+    border-radius: var(--#{$prefix}border-radius-xxl);
+  }
+
+  &-circle img {
+    border-radius: 50%;
+  }
 }
 
 // Add card-img-top to block img if class added to img block

--- a/assets/scss/bootscore/blocks/_blocks.scss
+++ b/assets/scss/bootscore/blocks/_blocks.scss
@@ -14,7 +14,14 @@ Block Widgets
 }
 
 
-// Add rounded-* classes to block img when class is added to the figure
+// Add width-100 classes to block img if class is added to the figure
+figure.w-100 {
+  img {
+    width: 100%;
+  }
+}
+
+// Add rounded-* classes to block img if class is added to the figure
 figure.rounded {
 
   img {
@@ -38,10 +45,12 @@ figure.rounded {
   }
 }
 
-// Add card-img-top to block img if class added to img block
-.card-img-top img {
-  border-top-left-radius: $card-inner-border-radius;
-  border-top-right-radius: $card-inner-border-radius;
+// Add card-img-top to block img if class added to the figure
+figure.card-img-top {
+  img {
+    border-top-left-radius: $card-inner-border-radius;
+    border-top-right-radius: $card-inner-border-radius;
+  }
 }
 
 

--- a/assets/scss/bootscore/blocks/_blocks.scss
+++ b/assets/scss/bootscore/blocks/_blocks.scss
@@ -15,7 +15,7 @@ Block Widgets
 
 
 // Add rounded to block img if class added to img block
-.rounded img {
+figure.rounded img {
   border-radius: var(--#{$prefix}border-radius);
 }
 

--- a/assets/scss/bootscore/blocks/_blocks.scss
+++ b/assets/scss/bootscore/blocks/_blocks.scss
@@ -81,3 +81,16 @@ figure.rounded {
     }
   }
 }
+
+
+// Add dark mode support to gallery/img block lightbox
+.wp-lightbox-overlay {
+  .scrim {
+    // Override inline-style 
+    background-color: var(--#{$prefix}body-bg) !important;
+  }
+}
+
+[data-bs-theme="dark"] .close-button {
+  filter: invert(1);
+}


### PR DESCRIPTION
- Fix: - `rounded` class only to selected block image instead adding class to all images inside a `rounded wrapper` https://github.com/bootscore/bootscore/pull/889/commits/aa32ecec3c059dd80b1810e6a371b928968505d8
- Added more `rounded-*` classes to the image block https://github.com/bootscore/bootscore/pull/889/commits/bd88a8e345904b3cd06956fa16dfa92c2cc214ef
- Added dark-mode support to gallery/img block lightbox https://github.com/bootscore/bootscore/pull/889/commits/f132631e65d64b9355b0430e80dd107ec34a58fa