### PR TITLE
Enqueue main.css to WP Pattern Editor

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -4,7 +4,7 @@
  * Enqueue styles & scripts
  *
  * @package Bootscore 
- * @version 6.0.0
+ * @version 6.0.3
  */
 
 
@@ -52,20 +52,27 @@ add_action('wp_enqueue_scripts', 'bootscore_scripts');
 
 
 
-/*
- * Register compiled CSS to editor
- */ 
+/**
+ * Register compiled CSS for block editor and Pattern Library
+ */
 function bootscore_add_editor_styles() {
+  // Add support for editor styles and main.css for the editor
   add_theme_support('editor-styles');
   add_editor_style('assets/css/main.css');
 
-  // Check if the current page is the Gutenberg editor and enqueue CSS to the main admin area to use variables in theme.json
-  $screen = get_current_screen();
-  if ($screen && $screen->is_block_editor) {
-    wp_enqueue_style('editor-style', get_stylesheet_directory_uri() . '/assets/css/editor.css', array(), '1.0', 'all');
-  }
+  // Enqueue additional styles for block editor and Pattern Library
+  add_action('admin_enqueue_scripts', function($hook_suffix) {
+    // Check if the current page is the block editor or the Pattern Library
+    $screen = get_current_screen();
+    
+    // Enqueue editor.css only in the block editor
+    if ($screen && $screen->is_block_editor) wp_enqueue_style('editor-style', get_stylesheet_directory_uri() . '/assets/css/editor.css', [], '1.0', 'all');
+
+    // Enqueue main.css only in the Pattern Library
+    if ('appearance_page_edit-wp-patterns' === $hook_suffix) wp_enqueue_style('bootscore-pattern-library-styles', get_template_directory_uri() . '/assets/css/main.css', [], wp_get_theme()->get('Version'));
+  });
 }
-add_action('enqueue_block_editor_assets', 'bootscore_add_editor_styles');
+add_action('after_setup_theme', 'bootscore_add_editor_styles');
 
 
 

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -51,7 +51,6 @@ function bootscore_scripts() {
 add_action('wp_enqueue_scripts', 'bootscore_scripts');
 
 
-
 /**
  * Register compiled CSS for block editor and Pattern Library
  */
@@ -62,18 +61,16 @@ function bootscore_add_editor_styles() {
 
   // Enqueue additional styles for block editor and Pattern Library
   add_action('admin_enqueue_scripts', function($hook_suffix) {
-    // Check if the current page is the block editor or the Pattern Library
     $screen = get_current_screen();
     
     // Enqueue editor.css only in the block editor
-    if ($screen && $screen->is_block_editor) wp_enqueue_style('editor-style', get_stylesheet_directory_uri() . '/assets/css/editor.css', [], '1.0', 'all');
+    if ($screen && $screen->is_block_editor) wp_enqueue_style('editor-style', get_stylesheet_directory_uri() . '/assets/css/editor.css');
 
     // Enqueue main.css only in the Pattern Library
-    if ('appearance_page_edit-wp-patterns' === $hook_suffix) wp_enqueue_style('bootscore-pattern-library-styles', get_template_directory_uri() . '/assets/css/main.css', [], wp_get_theme()->get('Version'));
+    if ('appearance_page_edit-wp-patterns' === $hook_suffix) wp_enqueue_style('bootscore-pattern-library-styles', get_stylesheet_directory_uri() . '/assets/css/main.css');
   });
 }
 add_action('after_setup_theme', 'bootscore_add_editor_styles');
-
 
 
 /**

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -52,25 +52,33 @@ add_action('wp_enqueue_scripts', 'bootscore_scripts');
 
 
 /**
- * Register compiled CSS for block editor and Pattern Library
+ * Register editor styles.
  */
 function bootscore_add_editor_styles() {
   // Add support for editor styles and main.css for the editor
   add_theme_support('editor-styles');
   add_editor_style('assets/css/main.css');
-
-  // Enqueue additional styles for block editor and Pattern Library
-  add_action('admin_enqueue_scripts', function($hook_suffix) {
-    $screen = get_current_screen();
-    
-    // Enqueue editor.css only in the block editor
-    if ($screen && $screen->is_block_editor) wp_enqueue_style('editor-style', get_stylesheet_directory_uri() . '/assets/css/editor.css');
-
-    // Enqueue main.css only in the Pattern Library
-    if ('appearance_page_edit-wp-patterns' === $hook_suffix) wp_enqueue_style('bootscore-pattern-library-styles', get_stylesheet_directory_uri() . '/assets/css/main.css');
-  });
 }
 add_action('after_setup_theme', 'bootscore_add_editor_styles');
+
+
+/**
+ * Enqueue styles for block editor and Pattern Library.
+ */
+function bootscore_enqueue_editor_and_pattern_library_styles($hook_suffix) {
+  $screen = get_current_screen();
+  
+  // Enqueue editor.css only in the block editor
+  if ($screen && $screen->is_block_editor) {
+    wp_enqueue_style('editor-style', get_stylesheet_directory_uri() . '/assets/css/editor.css');
+  }
+
+  // Enqueue main.css only in the Pattern Library
+  if ('appearance_page_edit-wp-patterns' === $hook_suffix) {
+    wp_enqueue_style('bootscore-pattern-library-styles', get_stylesheet_directory_uri() . '/assets/css/main.css');
+  }
+}
+add_action('admin_enqueue_scripts', 'bootscore_enqueue_editor_and_pattern_library_styles');
 
 
 /**


### PR DESCRIPTION
Adds missing compiled styles to the WP pattern editor to show patterns correctly **Backend > Appearance > Patterns**

| Before  | After |
| ------------- | ------------- |
| ![before](https://github.com/user-attachments/assets/ecf37137-b268-4806-a456-3445596488d1)  | ![after](https://github.com/user-attachments/assets/0a1bef86-0001-4c24-a8e0-1ef2c772b8c9)  |



