### PR TITLE
Remove select2 scripts and styles on blockified classic checkout

### DIFF
--- a/woocommerce/inc/wc-forms.php
+++ b/woocommerce/inc/wc-forms.php
@@ -4,7 +4,7 @@
  * WooCommerce Forms
  *
  * @package Bootscore
- * @version 6.0.0
+ * @version 6.0.4
  */
 
 


### PR DESCRIPTION
Update snippet to replace woo Select2 even on cart and checkout blocks.

Closes https://github.com/bootscore/bootscore/issues/918