### PR TITLE
Revert #919

### DIFF
--- a/woocommerce/inc/wc-forms.php
+++ b/woocommerce/inc/wc-forms.php
@@ -24,7 +24,11 @@ function bootscore_dequeue_styles_and_scripts_select2() {
   wp_dequeue_script('selectWoo');
   wp_deregister_script('selectWoo');
 
-  // Dequeue and deregister the country select script
+  // Dequeue and deregister the country select script. Needed for blockified classic checkout.
+  // Bug with stripe checkout payment. See:
+  // Issue: https://github.com/bootscore/bootscore/issues/918
+  // PR: https://github.com/bootscore/bootscore/pull/919
+  // Revert: https://github.com/bootscore/bootscore/pull/926
   //wp_dequeue_script('wc-country-select');
   //wp_deregister_script('wc-country-select');
 }

--- a/woocommerce/inc/wc-forms.php
+++ b/woocommerce/inc/wc-forms.php
@@ -25,8 +25,8 @@ function bootscore_dequeue_styles_and_scripts_select2() {
   wp_deregister_script('selectWoo');
 
   // Dequeue and deregister the country select script
-  wp_dequeue_script('wc-country-select');
-  wp_deregister_script('wc-country-select');
+  //wp_dequeue_script('wc-country-select');
+  //wp_deregister_script('wc-country-select');
 }
 add_action('wp_enqueue_scripts', 'bootscore_dequeue_styles_and_scripts_select2', 100);
 


### PR DESCRIPTION
@MicheleGrimaldi unfortunately figured out that this creates a bug with Stripe which makes it impossible to pay by credit card. I quickly commented the code to revert your PR and reopened the issue. So we have to check and fix this later. Until this has been solved, please use shortcode in checkout instead the blockified classic cart as described in the [docs](https://bootscore.me/documentation/woocommerce/#cart-and-checkout-since-wc-8-3).



- https://github.com/bootscore/bootscore/issues/918
- https://github.com/bootscore/bootscore/pull/919

![stripe](https://github.com/user-attachments/assets/9511e8c9-bb97-4d9d-8996-c5402e86b16a)
