### PR TITLE
Minor WC CSS fixes

### DIFF
--- a/assets/scss/bootscore-woocommerce/_wc-checkout.scss
+++ b/assets/scss/bootscore-woocommerce/_wc-checkout.scss
@@ -384,6 +384,11 @@ table.shop_table.woocommerce-checkout-review-order-table tr {
     display: none;
   }
       
+  // Fix blockified cart/checkout select2-container--open width 
+  // https://github.com/bootscore/bootscore/pull/1024
+  .select2-container {
+    width: auto;
+  }
 }
    
 // Validation    

--- a/assets/scss/bootscore-woocommerce/_wc-checkout.scss
+++ b/assets/scss/bootscore-woocommerce/_wc-checkout.scss
@@ -383,6 +383,7 @@ table.shop_table.woocommerce-checkout-review-order-table tr {
   .select2-container--default .select2-selection--single .select2-selection__arrow {
     display: none;
   }
+      
 }
    
 // Validation    

--- a/assets/scss/bootscore-woocommerce/_wc-my-account.scss
+++ b/assets/scss/bootscore-woocommerce/_wc-my-account.scss
@@ -83,3 +83,19 @@ WooCommerce My Account
     width: 100%;
   }
 }
+
+
+// Fix address spacing, WC breakpoint is 769px
+// https://github.com/bootscore/bootscore/pull/1024
+@media (max-width: 769px) {
+  .woocommerce .woocommerce-customer-details address {
+    margin-bottom: $spacer !important;
+  }
+}
+
+
+// Fix product meta
+// https://github.com/bootscore/bootscore/pull/1024
+.woocommerce td.product-name .wc-item-meta {
+  padding-left: 0;
+}

--- a/assets/scss/bootscore-woocommerce/_wc-product-variable.scss
+++ b/assets/scss/bootscore-woocommerce/_wc-product-variable.scss
@@ -39,3 +39,14 @@ form.variations_form.cart {
 .woocommerce-variation-price {
   margin-bottom: $spacer;
 }
+
+
+// Fix single variation product select icon (WC 9.8.5)
+// https://github.com/bootscore/bootscore/pull/1024
+.woocommerce div.product form.cart .variations select {
+  background: var(--#{$prefix}form-select-bg-img);
+  background-size: $form-select-bg-size;
+  -webkit-background-size: $form-select-bg-size;
+  background-repeat: no-repeat;
+  background-position: $form-select-bg-position;
+}


### PR DESCRIPTION
### Single variation product select bg-image:

| Before  | After |
| ------------- | ------------- |
| <img width="283" alt="Image" src="https://github.com/user-attachments/assets/be7cdd36-47e0-4db3-927b-8c6dfb53b459" />  | <img width="278" alt="Image" src="https://github.com/user-attachments/assets/8e7e12f9-27e6-4805-9c94-f147f07622e5" />  |



### My account addresses

| Before  | After |
| ------------- | ------------- |
| <img width="280" alt="Image" src="https://github.com/user-attachments/assets/ff0327ef-da20-4b08-809c-9d111e1004c7" />  | <img width="281" alt="Image" src="https://github.com/user-attachments/assets/578e5c8a-6500-43cb-8b23-abbbd2d5a3e2" /> |


### My account product meta

| Before  | After |
| ------------- | ------------- |
| <img width="276" alt="Image" src="https://github.com/user-attachments/assets/c74abe68-571b-46b8-9177-42623702c6de" />  | <img width="273" alt="Image" src="https://github.com/user-attachments/assets/ad4c18cc-bc9c-49fc-9aef-985c71ce6e23" />  |


### Blockified cart/checkout select2-container--open width 

| Before  | After |
| ------------- | ------------- |
| <img width="281" alt="Image" src="https://github.com/user-attachments/assets/26ef6044-f715-4346-baf0-68a99cbb79b6" />  | <img width="286" alt="Image" src="https://github.com/user-attachments/assets/d66b62e0-cad6-40e7-981c-277401d29090" />  |
