### PR TITLE
Feature/rework ajax cart

### DIFF
--- a/woocommerce/cart/mini-cart-footer.php
+++ b/woocommerce/cart/mini-cart-footer.php
@@ -1,0 +1,28 @@
+<?php
+  /**
+   * Mini-cart footer template
+   *
+   */
+
+?>
+
+<div>
+
+    <div class="woocommerce-mini-cart__total total h5 d-flex justify-content-between">
+      <?php
+        /**
+         * Hook: woocommerce_widget_shopping_cart_total.
+         *
+         * @hooked woocommerce_widget_shopping_cart_subtotal - 10
+         */
+        do_action('woocommerce_widget_shopping_cart_total');
+      ?>
+    </div>
+
+  <?php do_action('woocommerce_widget_shopping_cart_before_buttons'); ?>
+
+    <div class="woocommerce-mini-cart__buttons buttons"><?php do_action('woocommerce_widget_shopping_cart_buttons'); ?></div>
+
+  <?php do_action('woocommerce_widget_shopping_cart_after_buttons'); ?>
+
+</div>

--- a/woocommerce/cart/mini-cart-item.php
+++ b/woocommerce/cart/mini-cart-item.php
@@ -1,0 +1,118 @@
+<?php
+  /**
+   * Mini-cart item template
+   *
+   * @var string $cart_item_key Cart item key
+   * @var array{
+   *     data: WC_Product,
+   *     quantity: int,
+   *     variation: array,
+   *     variation_id: int
+   * } $cart_item Cart item data
+   */
+
+  defined('ABSPATH') || exit;
+
+  $_product = apply_filters('woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key);
+  $product_id = apply_filters('woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key);
+
+  if ($_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters('woocommerce_widget_cart_item_visible', true, $cart_item, $cart_item_key)) {
+    /**
+     * This filter is documented in woocommerce/templates/cart/cart.php.
+     *
+     * @since 2.1.0
+     */
+    $product_name = apply_filters('woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key);
+    $thumbnail = apply_filters('woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key);
+    $product_price = apply_filters('woocommerce_cart_item_price', WC()->cart->get_product_price($_product), $cart_item, $cart_item_key);
+    $product_permalink = apply_filters('woocommerce_cart_item_permalink', $_product->is_visible() ? $_product->get_permalink($cart_item) : '', $cart_item, $cart_item_key);
+    ?>
+      <div class="woocommerce-mini-cart-item list-group-item py-3 <?php echo esc_attr(apply_filters('woocommerce_mini_cart_item_class', 'mini_cart_item', $cart_item, $cart_item_key)); ?>"
+           data-bootscore_product_id="<?php echo esc_attr($product_id); ?>" data-key="<?php echo $cart_item_key; ?>">
+
+        <div class="row g-3">
+
+          <div class="item-image col-3">
+            <?php if (empty($product_permalink)) : ?>
+              <?php echo str_replace('<img', '<img class="rounded align-text-top"', $thumbnail); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php else : ?>
+                <a href="<?php echo esc_url($product_permalink); ?>">
+                  <?php echo str_replace('<img', '<img class="rounded align-text-top"', $thumbnail); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                </a>
+            <?php endif; ?>
+          </div>
+
+          <div class="item-name col-6">
+            <?php if (empty($product_permalink)) : ?>
+              <?php echo $product_name; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+              ?>
+            <?php else : ?>
+                <a class="cart-product-title <?= apply_filters('bootscore/class/cart/product-title', 'h6 text-decoration-none d-block text-truncate mb-0'); ?>"
+                   href="<?php echo esc_url($product_permalink); ?>">
+                  <?php echo $product_name; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                  ?>
+                </a>
+            <?php endif; ?>
+
+            <?php
+              if (apply_filters('bootscore/class/cart/enable_cart_product_excerpt', true)) { ?>
+                <p class="cart-product-excerpt <?= apply_filters('bootscore/class/cart/product-excerpt', 'small text-body-secondary text-truncate mb-0'); ?>">
+                  <?= get_the_excerpt($product_id); ?>
+                </p>
+              <?php }
+            ?>
+
+            <?php
+              if (apply_filters('bootscore/class/cart/enable_cart_stock_quantity', true)) {
+                $stock_quantity = $_product->get_stock_quantity();
+                // Check if the product is sold individually
+                if ($_product->is_sold_individually()) {
+                  echo '<div class="cart-badge mb-2"><span class="badge bg-danger">' . esc_html__('Sold individually', 'woocommerce') . '</span></div>';
+                } // Check if the product has only 5 or fewer left in stock
+                elseif ($stock_quantity <= 5 && $stock_quantity > 0) {
+                  $stock_message = sprintf(esc_html__('Only %s left in stock', 'woocommerce'), $stock_quantity);
+                  echo '<div class="cart-badge mb-2"><span class="badge bg-danger">' . $stock_message . '</span></div>';
+                }
+              }
+            ?>
+
+              <div class="item-quantity">
+                <?php echo wc_get_formatted_cart_item_data($cart_item); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                ?>
+                <?php echo apply_filters('woocommerce_widget_cart_item_quantity', '<span class="quantity">' . sprintf('<span class="qty_text">%s</span> &times; %s', $cart_item['quantity'], $product_price) . '</span>', $cart_item, $cart_item_key); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                ?>
+              </div>
+
+          </div>
+
+          <div class="remove col-3 text-end">
+
+            <div class="bootscore-custom-render-total h6 mb-4">
+              <?php echo WC()->cart->get_product_subtotal($_product, $cart_item['quantity']); // PHPCS: XSS ok.
+              ?>
+            </div>
+
+            <?php echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+              'woocommerce_cart_item_remove_link',
+              sprintf(
+                '<a href="%s" class="remove_from_cart_button link-danger" aria-label="%s" data-product_id="%s" data-cart_item_key="%s" data-product_sku="%s" data-success_message="%s">' . apply_filters('bootscore/icon/trash', '<i class="fa-regular fa-trash-can"></i>') . '</a>',
+                esc_url(wc_get_cart_remove_url($cart_item_key)),
+                /* translators: %s is the product name */
+                esc_attr(sprintf(__('Remove %s from cart', 'woocommerce'), wp_strip_all_tags($product_name))),
+                esc_attr($product_id),
+                esc_attr($cart_item_key),
+                esc_attr($_product->get_sku()),
+                /* translators: %s is the product name */
+                esc_attr(sprintf(__('&ldquo;%s&rdquo; has been removed from your cart', 'woocommerce'), wp_strip_all_tags($product_name)))
+              ),
+              $cart_item_key
+            );
+            ?>
+
+          </div>
+
+        </div><!--row-->
+
+      </div>
+    <?php
+  }

--- a/woocommerce/cart/mini-cart.php
+++ b/woocommerce/cart/mini-cart.php
@@ -1,165 +1,55 @@
 <?php
-/**
- * Mini-cart
- *
- * Contains the markup for the mini-cart, used by the cart widget.
- *
- * This template can be overridden by copying it to yourtheme/woocommerce/cart/mini-cart.php.
- *
- * HOWEVER, on occasion WooCommerce will need to update template files and you
- * (the theme developer) will need to copy the new files to your theme to
- * maintain compatibility. We try to do this as little as possible, but it does
- * happen. When this occurs the version of the template file will be bumped and
- * the readme will list any important changes.
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce\Templates
- * @version 9.4.0
- */
+  /**
+   * Mini-cart
+   *
+   * Contains the markup for the mini-cart, used by the cart widget.
+   *
+   * This template can be overridden by copying it to yourtheme/woocommerce/cart/mini-cart.php.
+   *
+   * HOWEVER, on occasion WooCommerce will need to update template files and you
+   * (the theme developer) will need to copy the new files to your theme to
+   * maintain compatibility. We try to do this as little as possible, but it does
+   * happen. When this occurs the version of the template file will be bumped and
+   * the readme will list any important changes.
+   *
+   * @see     https://docs.woocommerce.com/document/template-structure/
+   * @package WooCommerce\Templates
+   * @version 9.4.0
+   */
 
-defined('ABSPATH') || exit;
+  defined('ABSPATH') || exit;
 
-do_action('woocommerce_before_mini_cart'); ?>
+  do_action('woocommerce_before_mini_cart'); ?>
 
-<?php if ( WC()->cart && ! WC()->cart->is_empty() ) : ?>
+<?php if (WC()->cart && !WC()->cart->is_empty()) : ?>
 
-  <div class="woocommerce-mini-cart cart_list product_list_widget list-group list-group-flush <?php echo esc_attr($args['list_class']); ?>">
-    <?php
-    do_action('woocommerce_before_mini_cart_contents');
-
-    foreach (WC()->cart->get_cart() as $cart_item_key => $cart_item) {
-      $_product   = apply_filters('woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key);
-      $product_id = apply_filters('woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key);
-
-      if ($_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters('woocommerce_widget_cart_item_visible', true, $cart_item, $cart_item_key)) {
-        /**
-         * This filter is documented in woocommerce/templates/cart/cart.php.
-         *
-         @since 2.1.0
-         */
-        $product_name      = apply_filters('woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key);
-        $thumbnail         = apply_filters('woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key);
-        $product_price     = apply_filters('woocommerce_cart_item_price', WC()->cart->get_product_price($_product), $cart_item, $cart_item_key);
-        $product_permalink = apply_filters('woocommerce_cart_item_permalink', $_product->is_visible() ? $_product->get_permalink($cart_item) : '', $cart_item, $cart_item_key);
-        ?>
-        <div class="woocommerce-mini-cart-item list-group-item py-3 <?php echo esc_attr(apply_filters('woocommerce_mini_cart_item_class', 'mini_cart_item', $cart_item, $cart_item_key)); ?>" data-bootscore_product_id="<?php echo esc_attr($product_id); ?>" data-key="<?php echo $cart_item_key; ?>">
-
-          <div class="row g-3">
-
-            <div class="item-image col-3">
-              <?php if (empty($product_permalink)) : ?>
-                <?php echo str_replace( '<img', '<img class="rounded align-text-top"', $thumbnail ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-              <?php else : ?>
-                <a href="<?php echo esc_url($product_permalink); ?>">
-                  <?php echo str_replace( '<img', '<img class="rounded align-text-top"', $thumbnail ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                </a>
-              <?php endif; ?>
-            </div>
-
-            <div class="item-name col-6">
-              <?php if (empty($product_permalink)) : ?>
-                <?php echo $product_name; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
-                ?>
-              <?php else : ?>
-                <a class="cart-product-title <?= apply_filters('bootscore/class/cart/product-title', 'h6 text-decoration-none d-block text-truncate mb-0'); ?>" href="<?php echo esc_url($product_permalink); ?>">
-                  <?php echo $product_name; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                  ?>
-                </a>
-              <?php endif; ?>
-              
-              <?php
-                if (apply_filters('bootscore/class/cart/enable_cart_product_excerpt', true)) { ?>  
-                  <p class="cart-product-excerpt <?= apply_filters('bootscore/class/cart/product-excerpt', 'small text-body-secondary text-truncate mb-0'); ?>">
-                    <?= get_the_excerpt($product_id); ?>
-                  </p>
-              <?php  }
-              ?>   
-              
-              <?php
-                if (apply_filters('bootscore/class/cart/enable_cart_stock_quantity', true)) {
-                  $stock_quantity = $_product->get_stock_quantity();
-                  // Check if the product is sold individually
-                  if ($_product->is_sold_individually()) {
-                    echo '<div class="cart-badge mb-2"><span class="badge bg-danger">' . esc_html__('Sold individually', 'woocommerce') . '</span></div>';
-                  }
-                  // Check if the product has only 5 or fewer left in stock
-                  elseif ($stock_quantity <= 5 && $stock_quantity > 0) {
-                    $stock_message = sprintf(esc_html__('Only %s left in stock', 'woocommerce'), $stock_quantity);
-                    echo '<div class="cart-badge mb-2"><span class="badge bg-danger">' . $stock_message . '</span></div>';
-                  }
-                }
-              ?>              
-
-              <div class="item-quantity">
-                <?php echo wc_get_formatted_cart_item_data($cart_item); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
-                ?>
-                <?php echo apply_filters('woocommerce_widget_cart_item_quantity', '<span class="quantity">' . sprintf('<span class="qty_text">%s</span> &times; %s', $cart_item['quantity'], $product_price ) . '</span>', $cart_item, $cart_item_key); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                ?>
-              </div>
-              
-            </div>
-
-            <div class="remove col-3 text-end">
-              
-              <div class="bootscore-custom-render-total h6 mb-4">
-                <?php echo WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ); // PHPCS: XSS ok.
-                ?>
-              </div>
-              
-              <?php echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                'woocommerce_cart_item_remove_link',
-                sprintf(
-                  '<a href="%s" class="remove_from_cart_button link-danger" aria-label="%s" data-product_id="%s" data-cart_item_key="%s" data-product_sku="%s" data-success_message="%s">' . apply_filters('bootscore/icon/trash', '<i class="fa-regular fa-trash-can"></i>') . '</a>',
-                  esc_url(wc_get_cart_remove_url($cart_item_key)),
-                  /* translators: %s is the product name */
-                  esc_attr( sprintf( __( 'Remove %s from cart', 'woocommerce' ), wp_strip_all_tags( $product_name ) ) ),
-                  esc_attr($product_id),
-                  esc_attr($cart_item_key),
-                  esc_attr( $_product->get_sku() ),
-                  /* translators: %s is the product name */
-                  esc_attr( sprintf( __( '&ldquo;%s&rdquo; has been removed from your cart', 'woocommerce' ), wp_strip_all_tags( $product_name ) ) )
-                ),
-                $cart_item_key
-              );
-              ?>
-
-            </div>
-
-          </div><!--row-->
-
-        </div>
-        <?php
-      }
-    }
-
-    do_action('woocommerce_mini_cart_contents');
-    ?>
-  </div>
-
-  <div class="cart-footer <?= apply_filters('bootscore/class/header/cart/footer', 'bg-body-tertiary p-3'); ?>">
-
-    <div class="woocommerce-mini-cart__total total h5 d-flex justify-content-between">
+    <div class="woocommerce-mini-cart cart_list product_list_widget list-group list-group-flush <?php echo esc_attr($args['list_class']); ?>">
       <?php
-      /**
-       * Hook: woocommerce_widget_shopping_cart_total.
-       *
-       * @hooked woocommerce_widget_shopping_cart_subtotal - 10
-       */
-      do_action('woocommerce_widget_shopping_cart_total');
+        do_action('woocommerce_before_mini_cart_contents');
+
+        foreach (WC()->cart->get_cart() as $cart_item_key => $cart_item) {
+          wc_get_template(
+            'cart/mini-cart-item.php',
+            array(
+              'cart_item_key' => $cart_item_key,
+              'cart_item' => $cart_item
+            )
+          );
+        }
+
+        do_action('woocommerce_mini_cart_contents');
       ?>
     </div>
 
-    <?php do_action('woocommerce_widget_shopping_cart_before_buttons'); ?>
+    <div class="cart-footer <?= apply_filters('bootscore/class/header/cart/footer', 'bg-body-tertiary p-3'); ?>">
 
-    <div class="woocommerce-mini-cart__buttons buttons"><?php do_action('woocommerce_widget_shopping_cart_buttons'); ?></div>
+      <?php wc_get_template('cart/mini-cart-footer.php'); ?>
 
-    <?php do_action('woocommerce_widget_shopping_cart_after_buttons'); ?>
-
-  </div>
+    </div>
 
 <?php else : ?>
 
-  <p class="woocommerce-mini-cart__empty-message woocommerce-info m-3"><?php esc_html_e('No products in the cart.', 'woocommerce'); ?></p>
+    <p class="woocommerce-mini-cart__empty-message woocommerce-info m-3"><?php esc_html_e('No products in the cart.', 'woocommerce'); ?></p>
 
 <?php endif; ?>
 

--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -94,7 +94,7 @@ if ( 'no' !== $is_enabled_ajax_cart ) {
             }
           });
 
-          // Add loading spinner to add_to_cart_button // loop buttons are added via fn-wc-archive.php
+          // Add loading spinner to add_to_cart_button // loop buttons are via a php filter in ajax-cart.php
           $('.single_add_to_cart_button').prepend('<div class="btn-loader"><span class="spinner-border spinner-border-sm"></span></div>');
 
         });
@@ -199,6 +199,24 @@ if ( 'no' !== $is_enabled_ajax_cart ) {
     <?php
   }
   add_action('wp_footer', 'bootscore_product_page_ajax_add_to_cart_js');
+
+  function bootscore_add_btn_loader_to_loop( $html ) {
+    global $product;
+
+    // Check if product is in stock
+    if(!$product->is_in_stock()) {
+      return 	'<p class="stock out-of-stock text-wrap mb-0 mt-auto">' .
+        esc_html( apply_filters( 'woocommerce_out_of_stock_message', __( 'This product is currently out of stock and unavailable.', 'woocommerce' ) ) ) .
+        '</p>';
+    }
+
+    // Implement Buttonloader directly without js
+    $pattern = '/(<a href=\"\?add-to-cart=[^>]+>)/';
+    $replacement = '$1<div class="btn-loader"><span class="spinner-border spinner-border-sm"></span></div>';
+
+    return preg_replace($pattern, $replacement, $html);
+  }
+  add_filter( 'woocommerce_loop_add_to_cart_link', 'bootscore_add_btn_loader_to_loop', 12 );
 
 function bootscore_ajax_add_to_cart_js() {
   ?>

--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -600,7 +600,7 @@ function bootscore_qty_update(){
       } else {
         $cart_total = WC()->cart->get_cart_total();
       }
-      $response_item['fragments_replace']['.woocommerce-mini-cart__total.total .amount > bdi'] = $cart_total;
+      $response_item['fragments_replace']['.cart-toggler .woocommerce-Price-amount > bdi'] = $cart_total;
       $response_item['fragments_replace']['.cart-content-count'] = '<span class="cart-content-count position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">' . WC()->cart->get_cart_contents_count() . '</span>';
 
       wc_add_notice("Quantity of {$updated_item['data']->get_name()} updated successfully", 'success');

--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -222,8 +222,43 @@ function bootscore_ajax_add_to_cart_js() {
   ?>
   <script>
     jQuery(function ($) {
+      // Handling of quantity buttons in single product form, has nothing to do with ajax cart.
+      $(document.body).on('click', 'form.cart .plus, form.cart .minus,' + // for single product page
+        'form.woocommerce-cart-form .plus, form.woocommerce-cart-form .minus', // legacy cart
+        function () {
+        let $qty = $(this).closest('.quantity').find('.qty'),
+          currentVal = parseInt($qty.val()),
+          max = parseInt($qty.attr('max')),
+          min = parseInt($qty.attr('min')),
+          step = $qty.attr('step');
 
-      $(document.body).on('click', '.plus, .minus', function () {
+        // Format values
+        if (! currentVal || currentVal === '' || currentVal === 'NaN') currentVal = 0;
+        if (max === '' || max === 'NaN') max = '';
+        if (min === '' || min === 'NaN') min = 0;
+        if (step === 'any' || step === '' || step === undefined || parseInt(step) === 'NaN'){ step = 1; }
+
+        // Perform the Quantity Update for Increment.
+        let newVal = currentVal;
+        if ($(this).is('.plus')) {
+          newVal += parseInt(step);
+          // As the value on page load is always 1 or the min value, the minus button will be disabled by default.
+          // As soon as we add some quantity, we enable the minus button. On further clicks you could go on 0 but
+          // would get notified immediatly by the html validation
+          $(this).closest('.quantity').find('.minus').attr('disabled', false);
+        } else {
+          newVal -= parseInt(step);
+        }
+
+        $qty.val( newVal );
+        $qty[0].reportValidity();
+
+        // needed to enable refresh cart button on legacy cart page
+        $qty.trigger('change');
+      });
+
+    // Handling of quantity buttons in the ajax mini cart qty buttons
+      $(document.body).on('click', '.item-quantity .plus, .item-quantity .minus', function () {
         let $qty = $(this).closest('.quantity').find('.qty'),
           currentVal = parseInt($qty.val()),
           max = parseInt($qty.attr('max')),
@@ -237,9 +272,7 @@ function bootscore_ajax_add_to_cart_js() {
           currentVal = 0;
         if (max === '' || max === 'NaN') max = '';
         if (min === '' || min === 'NaN') min = 0;
-        if (step === 'any' || step === '' || step === undefined || parseInt(step) === 'NaN'){
-          step = 1;
-        }
+        if (step === 'any' || step === '' || step === undefined || parseInt(step) === 'NaN'){ step = 1; }
 
         // Perform the Quantity Update for Increment.
         if ($(this).is('.plus')) {

--- a/woocommerce/inc/wc-qty-btn.php
+++ b/woocommerce/inc/wc-qty-btn.php
@@ -1,53 +1,73 @@
 <?php
 
-/**
- * WooCommerce Quantity Buttons
- *
- * @package Bootscore 
- * @version 6.0.0
- */
-
+  /**
+   * WooCommerce Quantity Buttons
+   *
+   * @package Bootscore
+   * @version 6.0.0
+   */
 
 // Exit if accessed directly
-defined('ABSPATH') || exit;
+  defined('ABSPATH') || exit;
 
+  /**
+   * This snippet can be used to force the quantity input to display in cases where
+   * the input value cannot be changed (which is when the product is set to be sold
+   * individually, or when the min and max values are identical).
+   * See https://github.com/woocommerce/woocommerce/pull/36460
+   * See https://github.com/bootscore/bootscore/pull/543/commits/57574c1fdd4ad10d296df70e51cf08b801fccb27
+   */
+  add_filter('woocommerce_quantity_input_args', function (array $args) {
+    add_filter('woocommerce_quantity_input_type', 'change_quantity_input_type');
 
-/**
- * Add -/+ buttons to quantity-input.php
- */
-add_action('woocommerce_before_quantity_input_field', 'bs_quantity_minus_button');
+    // Both Buttons are enabled
+    if (($args['max_value'] < 1 && $args['input_value'] > 1) || ($args['min_value'] < $args['input_value'] && $args['input_value'] < $args['max_value'])) {
+      add_action('woocommerce_before_quantity_input_field', 'bs_quantity_minus_button');
+      add_action('woocommerce_after_quantity_input_field', 'bs_quantity_plus_button');
 
-function bs_quantity_minus_button() {
-  echo '<div class="input-group"><button type="button" class="minus input-group-text" data-type="minus">-</button>';
-}
+      remove_action('woocommerce_before_quantity_input_field', 'bs_quantity_minus_button_disabled');
+      remove_action('woocommerce_after_quantity_input_field', 'bs_quantity_plus_button_disabled');
+    } elseif ($args['input_value'] == $args['min_value'] || $args['input_value'] == 1) {
+      add_action('woocommerce_before_quantity_input_field', 'bs_quantity_minus_button_disabled');
+      add_action('woocommerce_after_quantity_input_field', 'bs_quantity_plus_button');
 
-add_action('woocommerce_after_quantity_input_field', 'bs_quantity_plus_button');
+      remove_action('woocommerce_before_quantity_input_field', 'bs_quantity_minus_button');
+      remove_action('woocommerce_after_quantity_input_field', 'bs_quantity_plus_button_disabled');
+    } elseif ($args['input_value'] == $args['max_value']) {
+      add_action('woocommerce_before_quantity_input_field', 'bs_quantity_minus_button');
+      add_action('woocommerce_after_quantity_input_field', 'bs_quantity_plus_button_disabled');
 
-function bs_quantity_plus_button() {
-  echo '<button type="button" class="plus input-group-text" data-type="plus">+</button></div>';
-}
+      remove_action('woocommerce_before_quantity_input_field', 'bs_quantity_minus_button_disabled');
+      remove_action('woocommerce_after_quantity_input_field', 'bs_quantity_plus_button');
+    } else {
+      add_action('woocommerce_before_quantity_input_field', 'bs_quantity_minus_button_disabled');
+      add_action('woocommerce_after_quantity_input_field', 'bs_quantity_plus_button_disabled');
 
-add_action('wp_header', 'bs_quantity_plus_minus');
+      remove_action('woocommerce_before_quantity_input_field', 'bs_quantity_minus_button');
+      remove_action('woocommerce_after_quantity_input_field', 'bs_quantity_plus_button');
 
+      $args['readonly'] = true;
+    }
 
-/**
- * This snippet can be used to force the quantity input to display in cases where
- * the input value cannot be changed (which is when the product is set to be sold
- * individually, or when the min and max values are identical).
- * See https://github.com/woocommerce/woocommerce/pull/36460
- * See https://github.com/bootscore/bootscore/pull/543/commits/57574c1fdd4ad10d296df70e51cf08b801fccb27
- */
-add_filter('woocommerce_quantity_input_args', function (array $args) {
-
-  if ($args['max_value'] < 1 || $args['min_value'] !== $args['max_value']) {
-    remove_filter('woocommerce_quantity_input_type', 'change_quantity_input_type');
     return $args;
-  }
-  add_filter('woocommerce_quantity_input_type', 'change_quantity_input_type');
-  $args['readonly'] = true;
-  return $args;
-});
+  });
 
-function change_quantity_input_type() {
-  return 'number';
-}
+  function change_quantity_input_type() {
+    return 'number';
+  }
+
+  function bs_quantity_minus_button() {
+    echo '<div class="input-group"><button type="button" class="minus input-group-text" data-type="minus">-</button>';
+  }
+
+  function bs_quantity_minus_button_disabled() {
+    echo '<div class="input-group"><button type="button" class="minus input-group-text disabled" disabled="disabled" data-type="minus">-</button>';
+  }
+
+  function bs_quantity_plus_button() {
+    echo '<button type="button" class="plus input-group-text" data-type="plus">+</button></div>';
+  }
+
+  function bs_quantity_plus_button_disabled() {
+    echo '<button type="button" class="plus input-group-text disabled" disabled="disabled" data-type="plus">+</button></div>';
+  }


### PR DESCRIPTION
- Refactors the mini-cart to use fragments for more granular updates,
- improves the user experience, and prevents full page reloads.
- Adds support for displaying WooCommerce notices as toasts in the
- mini-cart and implements a filter to enable or disable toasts.
- Improves quantity update functionality in the mini-cart, including
- validation and handling of cart updates and error messages.
- Show removal of products as well.
- Splits mini-cart template into separate files