### PR TITLE
Fix errors in debug mode with incorrect pattern file names

### DIFF
--- a/patterns/c-alert-danger.php
+++ b/patterns/c-alert-danger.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: c - Alert-danger with icon and dismiss button
- * Slug: bootscore/c.alert-danger
+ * Slug: bootscore/c-alert-danger
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/c-alert-info.php
+++ b/patterns/c-alert-info.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: c - Alert-info
- * Slug: bootscore/c.alert-info
+ * Slug: bootscore/c-alert-info
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/c-btn-danger-lg.php
+++ b/patterns/c-btn-danger-lg.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: c - Button danger lg
- * Slug: bootscore/c.btn-danger-lg
+ * Slug: bootscore/c-btn-danger-lg
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/c-btn-outline-secondary-sm.php
+++ b/patterns/c-btn-outline-secondary-sm.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: c - Button outline-secondary sm
- * Slug: bootscore/c.btn-outline-secondary-sm
+ * Slug: bootscore/c-btn-outline-secondary-sm
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/c-btn-primary.php
+++ b/patterns/c-btn-primary.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: c - Button primary
- * Slug: bootscore/c.btn-primary
+ * Slug: bootscore/c-btn-primary
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/c-card-basic.php
+++ b/patterns/c-card-basic.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: c - Card basic with image
- * Slug: bootscore/c.card-basic
+ * Slug: bootscore/c-card-basic
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/c-card-header-footer.php
+++ b/patterns/c-card-header-footer.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: c - Card with header and footer
- * Slug: bootscore/c.card-header-footer
+ * Slug: bootscore/c-card-header-footer
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/c-card-widget-categories.php
+++ b/patterns/c-card-widget-categories.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: c - Card with category widget
- * Slug: bootscore/c.card-widget-categories
+ * Slug: bootscore/c-card-widget-categories
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/c-cards-pricing.php
+++ b/patterns/c-cards-pricing.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: c - Cards pricing
- * Slug: bootscore/c.cards-pricing
+ * Slug: bootscore/c-cards-pricing
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/c-hero-img-left.php
+++ b/patterns/c-hero-img-left.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: c - Hero img left
- * Slug: bootscore/c.hero-img-left
+ * Slug: bootscore/c-hero-img-left
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/c-hero-img-right.php
+++ b/patterns/c-hero-img-right.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: c - Hero img right
- * Slug: bootscore/hero-img-right
+ * Slug: bootscore/c-hero-img-right
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/c-hero-jumbotron.php
+++ b/patterns/c-hero-jumbotron.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: c - Hero jumbotron
- * Slug: bootscore/c.hero-jumbotron
+ * Slug: bootscore/c-hero-jumbotron
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/l-container.php
+++ b/patterns/l-container.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: l - Container
- * Slug: bootscore/l.container
+ * Slug: bootscore/l-container
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/l-grid-col-3.php
+++ b/patterns/l-grid-col-3.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: l - Grid 3/3/3/3
- * Slug: bootscore/l.grid-col-3
+ * Slug: bootscore/l-grid-col-3
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/l-grid-col-4-col-8.php
+++ b/patterns/l-grid-col-4-col-8.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: l - Grid 4/8
- * Slug: bootscore/l.grid-col-4-col-8
+ * Slug: bootscore/l-grid-col-4-col-8
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/l-grid-col-6.php
+++ b/patterns/l-grid-col-6.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: l - Grid 6/6
- * Slug: bootscore/l.grid-col-6
+ * Slug: bootscore/l-grid-col-6
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/l-grid-col-8-col-4.php
+++ b/patterns/l-grid-col-8-col-4.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: l - Grid 8/4
- * Slug: bootscore/l.grid-col-8-col-4
+ * Slug: bootscore/l-grid-col-8-col-4
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/s-heading-subtitle.php
+++ b/patterns/s-heading-subtitle.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: s - Heading and subtitle
- * Slug: s.heading-subtitle
+ * Slug: s-heading-subtitle
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/s-hero-img-left.php
+++ b/patterns/s-hero-img-left.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: s - Hero image left
- * Slug: bootscore/s.hero-img-left
+ * Slug: bootscore/s-hero-img-left
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/s-hero-img-right.php
+++ b/patterns/s-hero-img-right.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: s - Hero image right
- * Slug: bootscore/s.hero-img-right
+ * Slug: bootscore/s-hero-img-right
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 

--- a/patterns/s-hero-jumbotron.php
+++ b/patterns/s-hero-jumbotron.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: s - Hero jumbotron
- * Slug: bootscore/s.hero-jumbotron
+ * Slug: bootscore/s-hero-jumbotron
  * Categories: bootscore
  * https://developer.wordpress.org/themes/features/block-patterns/
  * 


### PR DESCRIPTION
@gorobey I saw that you fixed the bugs with the incorrect pattern names in debug mode https://github.com/bootscore/bootscore/commit/b94f2b4bddf1c0ab3b83650d63f8621edb14db89 coming with v 6.2. I quickly created a  pull request for that. Are you ok that we merge your fix commit to the theme? I think this should be solved soon.

Thank you