### PR TITLE
Feature/ajax cart enable view transition api

### DIFF
--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -215,6 +215,7 @@
 
           // Look for Items added to the cart while updating - E.g. if there is a bogo plugin active that adds a different item:
           $new_items = array_diff_key($cart_content_after, $cart_content_before);
+          if( !empty( $new_items ) ) { $response_item['fragments_append'][".woocommerce-mini-cart.cart_list"] = ''; }
           foreach ($new_items as $key => $item) {
             $response_item['fragments_append'][".woocommerce-mini-cart.cart_list"] .= retrieve_cart_item_html($key, $item);
             wc_add_notice( sprintf(__( '&ldquo;%s&rdquo; has been added to your cart', 'woocommerce' ), $item['data']->get_title()), 'success' );

--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -202,7 +202,11 @@
           $response_item['fragments_replace']['.cart-toggler .woocommerce-Price-amount > bdi'] = $cart_total;
           $response_item['fragments_replace']['.cart-content-count'] = '<span class="cart-content-count position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">' . WC()->cart->get_cart_contents_count() . '</span>';
 
-          wc_add_notice(sprintf(__("Quantity of %s updated successfully", 'bootscore'), $updated_item['data']->get_name()), 'success');
+          if($qty == 0){
+            wc_add_notice(sprintf(__('&ldquo;%s&rdquo; has been removed from your cart', 'woocommerce'), $updated_item['data']->get_name()), 'success');
+          } else {
+            wc_add_notice(sprintf(__("Quantity of %s updated successfully", 'bootscore'), $updated_item['data']->get_name()), 'success');
+          }
 
           // Filter to force complete fragments refresh on qty update if some incompatibility comes up.
           $response_item['force_fragments_refresh'] = apply_filters('bootscore/woocommerce/ajax-cart/update-qty/response/force-full-refresh', false, $response_item, $cart_item_key, $qty);
@@ -276,15 +280,6 @@
       }
       return $passed;
     }
-
-    // Show removal of products as well
-    add_action('woocommerce_remove_cart_item', function ($cart_item_key, $cart) {
-      $removed = $cart->removed_cart_contents[$cart_item_key];
-      $product_name = wc_get_product($removed['product_id'])->get_name();
-
-      // Add your notice (WC will show these via AJAX too)
-      wc_add_notice(sprintf(__('&ldquo;%s&rdquo; has been removed from your cart', 'woocommerce'), $product_name), 'success');
-    }, 10, 2);
 
     add_filter('woocommerce_widget_cart_item_quantity', 'add_minicart_quantity_fields', 10, 3);
     function add_minicart_quantity_fields($html, $cart_item, $cart_item_key)

--- a/woocommerce/js/ajax-cart.js
+++ b/woocommerce/js/ajax-cart.js
@@ -255,13 +255,11 @@ jQuery(function ($) {
               cart_res['total']
             );
 
-            $.each(cart_res['fragments_replace'], function (selector, content) {
-              $(selector).replaceWith(content);
-            });
-
-            $.each(cart_res['fragments_append'], function (selector, content) {
-              $(selector).append(content);
-            });
+            if (document.startViewTransition) {
+              document.startViewTransition(() => updateCartFragments(cart_res));
+            } else {
+              updateCartFragments(cart_res);
+            }
 
             // Dispatch the custom event
             $(document.body).trigger('qty_updated', [res]);
@@ -269,13 +267,11 @@ jQuery(function ($) {
         } else {
           wrap.find('.blockUI').remove();
 
-          $.each(cart_res['fragments_replace'], function (selector, content) {
-            $(selector).replaceWith(content);
-          });
-
-          $.each(cart_res['fragments_append'], function (selector, content) {
-            $(selector).append(content);
-          });
+          if (document.startViewTransition) {
+            document.startViewTransition(() => updateCartFragments(cart_res));
+          } else {
+            updateCartFragments(cart_res);
+          }
 
           $(document.body).trigger('qty_update_failed', [res]);
         }
@@ -290,6 +286,19 @@ jQuery(function ($) {
       },
     });
   }
+
+  function updateCartFragments(cart_res) {
+    // Replace fragments
+    $.each(cart_res['fragments_replace'], function (selector, content) {
+      $(selector).replaceWith(content);
+    });
+
+    // Append fragments
+    $.each(cart_res['fragments_append'], function (selector, content) {
+      $(selector).append(content);
+    });
+  }
+
 
   // 3. General Offcanvas Cart behaviour
 

--- a/woocommerce/js/ajax-cart.js
+++ b/woocommerce/js/ajax-cart.js
@@ -170,13 +170,13 @@ jQuery(function ($) {
     var input = $(this),
       max = input.attr('max'),
       currentValue = input.val(),
-      intValue = Math.max(Math.ceil(parseInt(currentValue)), 1),
+      intValue = Math.max(Math.ceil(parseInt(currentValue)), 0),
       nonce = $('input[name="bootscore_update_cart_nonce"]').val(),
       product_id = $(this).closest('.list-group-item').attr('data-bootscore_product_id');
 
     input.val(intValue);
 
-    if (currentValue === '' || parseInt(currentValue) === '0' || intValue === NaN) {
+    if (currentValue === '' || intValue === NaN) {
       input.val(1);
       intValue = 1;
     }
@@ -199,6 +199,21 @@ jQuery(function ($) {
     // Perform the Quantity Update.
     let wrap = $(input).closest('.woocommerce-mini-cart-item');
     bootscore_quantity_update(wrap, intValue, nonce, product_id, max);
+  });
+
+  // Remove items with a modified update quantity method
+  $('body').on('click', '.remove_from_cart_button', function (e) {
+    e.preventDefault();
+
+    var input = $(this),
+        nonce = $('input[name="bootscore_update_cart_nonce"]').val(),
+        product_id = $(this).closest('.list-group-item').attr('data-bootscore_product_id');
+
+    console.log('remove_from_cart_button');
+
+    // Perform the Quantity Update.
+    let wrap = $(input).closest('.woocommerce-mini-cart-item');
+    bootscore_quantity_update(wrap, 0, nonce, product_id);
   });
 
   function bootscore_quantity_update(wrap, number, nonce, product_id, max = -1, step = 1) {


### PR DESCRIPTION
Ads a view-transition-api wrapper to the ajax cart replacements to enable standard behaviour progressively and allows for improvement via css.