### PR TITLE
Fixes double cart item removal

### DIFF
--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -213,6 +213,9 @@
 
           $cart_content_after = WC()->cart->get_cart();
 
+          // If the cart is empty, we need to force a full refresh.
+          if( WC()->cart->get_cart_contents_count() == 0) $response_item['force_fragments_refresh'] = true;
+
           // Look for Items added to the cart while updating - E.g. if there is a bogo plugin active that adds a different item:
           $new_items = array_diff_key($cart_content_after, $cart_content_before);
           if( !empty( $new_items ) ) { $response_item['fragments_append'][".woocommerce-mini-cart.cart_list"] = ''; }

--- a/woocommerce/inc/wc-enqueue.php
+++ b/woocommerce/inc/wc-enqueue.php
@@ -42,7 +42,7 @@ function bootscore_wc_scripts() {
 
     $modified_ajaxCart_JS = date('YmdHi', filemtime(get_template_directory() . '/woocommerce/js/ajax-cart.js'));
 
-    wp_enqueue_script('bootscore-ajax-cart-script', get_template_directory_uri() . '/woocommerce/js/ajax-cart.js', array(), $modified_ajaxCart_JS, true);
+    wp_enqueue_script('bootscore-ajax-cart-script', get_template_directory_uri() . '/woocommerce/js/ajax-cart.js', array('wc-add-to-cart'), $modified_ajaxCart_JS, true);
     //wp_set_script_translations('bootscore-ajax-cart-script', 'bootscore', get_template_directory() . '/languages');
   }
 

--- a/woocommerce/js/ajax-cart.js
+++ b/woocommerce/js/ajax-cart.js
@@ -201,6 +201,9 @@ jQuery(function ($) {
     bootscore_quantity_update(wrap, intValue, nonce, product_id, max);
   });
 
+  // Remove original handler:
+  $(document.body).off('click', '.remove_from_cart_button');
+
   // Remove items with a modified update quantity method
   $('body').on('click', '.remove_from_cart_button', function (e) {
     e.preventDefault();


### PR DESCRIPTION
Addresses an issue where removing items from the cart resulted in a double removal due to conflicting event handlers.

Also ensures a full refresh when the cart becomes empty.

Adds 'wc-add-to-cart' as a dependency for the ajax-cart script.