### PR TITLE
Add a `scroll-margin-top` to id's in main content

### DIFF
--- a/assets/scss/bootscore/_header.scss
+++ b/assets/scss/bootscore/_header.scss
@@ -8,6 +8,6 @@ Header - Bootscore v6.3.0
 
 // Using the [id] sesector instead
 // https://piccalil.li/blog/add-scroll-margin-to-all-elements-which-can-be-targeted/
-main [id] {
+[id] {
   scroll-margin-top: var(--#{$prefix}scroll-margin-top, 55px); // 55px default navbar height
 }

--- a/assets/scss/bootscore/_header.scss
+++ b/assets/scss/bootscore/_header.scss
@@ -6,7 +6,7 @@ Header - Bootscore v6.3.0
 // Setting the scroll-padding to the <html> creates issues with offcanvas
 // https://github.com/twbs/bootstrap/issues/41615
 
-// Using the [id] sesector instead
+// Using the [id] selector instead
 // https://piccalil.li/blog/add-scroll-margin-to-all-elements-which-can-be-targeted/
 [id] {
   scroll-margin-top: var(--#{$prefix}scroll-margin-top, 55px); // 55px default navbar height

--- a/assets/scss/bootscore/_header.scss
+++ b/assets/scss/bootscore/_header.scss
@@ -1,13 +1,13 @@
 /*--------------------------------------------------------------
-Header
+Header - Bootscore v6.3.0
 --------------------------------------------------------------*/
 
 
-// Setting the scroll-padding to the <html> creates issues in Safari with the new .sticky-top header position.
-// Disable it roughly and try to find a solution later.
-/*
-// Navbar height
-html {
-  scroll-padding-top: 55px;
+// Setting the scroll-padding to the <html> creates issues with offcanvas
+// https://github.com/twbs/bootstrap/issues/41615
+
+// Using the [id] sesector instead
+// https://piccalil.li/blog/add-scroll-margin-to-all-elements-which-can-be-targeted/
+main [id] {
+  scroll-margin-top: var(--#{$prefix}scroll-margin-top, 55px); // 55px default navbar height
 }
-*/

--- a/assets/scss/bootscore/_header.scss
+++ b/assets/scss/bootscore/_header.scss
@@ -3,7 +3,7 @@ Header - Bootscore v6.3.0
 --------------------------------------------------------------*/
 
 
-// Setting the scroll-padding to the <html> creates issues with offcanvas
+// Setting the scroll-margin to the <html> creates issues with offcanvas
 // https://github.com/twbs/bootstrap/issues/41615
 
 // Using the [id] selector instead


### PR DESCRIPTION
Closes https://github.com/bootscore/bootscore/issues/1062

Scroll-margin (default navbar height) can be changed in the `_custom.scss` file

```scss
:root {
  --#{$prefix}scroll-margin-top: 200px;
}
```