### PR TITLE
Adds product context to out-of-stock badge filter

### DIFF
--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -67,7 +67,7 @@
           esc_html(
             apply_filters('bootscore/woocommerce/loop/out-of-stock-badge-text',
               apply_filters('woocommerce_out_of_stock_message', __('This product is currently out of stock and unavailable.', 'woocommerce'))
-            )
+              , $product )
           ) .
           '</p>';
 


### PR DESCRIPTION
Ensures that the "bootscore/woocommerce/loop/out-of-stock-badge-text"
filter receives the product context, enabling more specific
customization of the out-of-stock badge text.
