### PR TITLE
linking parents, current category as text

### DIFF
--- a/inc/breadcrumb.php
+++ b/inc/breadcrumb.php
@@ -15,29 +15,52 @@ defined('ABSPATH') || exit;
 /**
  * Breadcrumb
  */
-if (!function_exists('the_breadcrumb')) :
-  function the_breadcrumb() {
+if (!function_exists('the_breadcrumb')) {
+    function the_breadcrumb() {
 
-    if (!is_home()) {
-      echo '<nav aria-label="breadcrumb" class="' . apply_filters('bootscore/class/breadcrumb/nav', 'overflow-x-auto text-nowrap mb-4 mt-2 py-2 px-3 bg-body-tertiary rounded') . '">';
-      echo '<ol class="breadcrumb ' . apply_filters('bootscore/class/breadcrumb/ol', 'flex-nowrap mb-0') . '">';
-      echo '<li class="breadcrumb-item"><a class="' . apply_filters('bootscore/class/breadcrumb/item/link', '') . '" href="' . home_url() . '">' . '' . apply_filters('bootscore/icon/home', '<i class="fa-solid fa-house"></i>') . '<span class="visually-hidden">' . __('Home', 'bootscore') . '</span>' . '</a></li>';
-      // display parent category names with links
-      if (is_category() || is_single()) {
-        $cat_IDs = wp_get_post_categories(get_the_ID());
-        foreach ($cat_IDs as $cat_ID) {
-          $cat = get_category($cat_ID);
-          echo '<li class="breadcrumb-item"><a class="' . apply_filters('bootscore/class/breadcrumb/item/link', '') . '" href="' . get_term_link($cat->term_id) . '">' . $cat->name . '</a></li>';
+        if (is_home()) {
+            return;
         }
-      }
-      // display current page name
-      if (is_page() || is_single()) {
-        echo '<li class="breadcrumb-item active" aria-current="page">' . get_the_title() . '</li>';
-      }
-      echo '</ol>';
-      echo '</nav>';
-    }
-  }
 
-  add_filter('breadcrumbs', 'breadcrumbs');
-endif;
+        echo '<nav aria-label="breadcrumb" class="' . apply_filters('bootscore/class/breadcrumb/nav', 'overflow-x-auto text-nowrap mb-4 mt-2 py-2 px-3 bg-body-tertiary rounded') . '">' . PHP_EOL;
+        echo '<ol class="breadcrumb ' . apply_filters('bootscore/class/breadcrumb/ol', 'flex-nowrap mb-0') . '">' . PHP_EOL;
+
+        // home
+        echo '<li class="breadcrumb-item"><a aria-label="' . esc_attr__('Home', 'bootscore') . '" class="' . esc_attr(apply_filters('bootscore/class/breadcrumb/item/link', '')) . '" href="' . esc_url(home_url()) . '">' . apply_filters('bootscore/icon/home', '<i class="fa-solid fa-house" aria-hidden="true"></i>') . '</a></li>' . PHP_EOL;
+
+        // category-archive: linking parents, current category as text
+        if (is_category()) {
+            $current_cat_id = get_queried_object_id();
+            if ($current_cat_id) {
+                $ancestors = array_reverse(get_ancestors($current_cat_id, 'category'));
+                foreach ($ancestors as $ancestor_id) {
+                    $ancestor = get_category($ancestor_id);
+                    if ($ancestor && !is_wp_error($ancestor)) {
+                        echo '<li class="breadcrumb-item"><a class="' . esc_attr(apply_filters('bootscore/class/breadcrumb/item/link', '')) . '" href="' . esc_url(get_term_link($ancestor)) . '">' . esc_html($ancestor->name) . '</a></li>' . PHP_EOL;
+                    }
+                }
+                echo '<li class="breadcrumb-item active" aria-current="page">' . esc_html(single_cat_title('', false)) . '</li>' . PHP_EOL;
+            }
+        }
+        // single-post: linking category, after that title as text
+        elseif (is_single()) {
+            $cat_ids = wp_get_post_categories(get_the_ID());
+            foreach ($cat_ids as $cat_id) {
+                $cat = get_category($cat_id);
+                if ($cat && !is_wp_error($cat)) {
+                    echo '<li class="breadcrumb-item"><a class="' . esc_attr(apply_filters('bootscore/class/breadcrumb/item/link', '')) . '" href="' . esc_url(get_term_link($cat)) . '">' . esc_html($cat->name) . '</a></li>' . PHP_EOL;
+                }
+            }
+            echo '<li class="breadcrumb-item active" aria-current="page">' . esc_html(get_the_title()) . '</li>' . PHP_EOL;
+        }
+        // page
+        elseif (is_page()) {
+            echo '<li class="breadcrumb-item active" aria-current="page">' . esc_html(get_the_title()) . '</li>' . PHP_EOL;
+        }
+
+        echo '</ol>' . PHP_EOL;
+        echo '</nav>' . PHP_EOL;
+    }
+
+    add_filter('breadcrumbs', 'breadcrumbs');
+}


### PR DESCRIPTION
When you are reaching the archive of a category, the link of the category was still shown at the breadcrumb-navigation because there is no check existing, if you are already inside of a specific categories-archive. For this case, the link to the same category isn't needed at the breadcrumb-navigation because there is no other target available, than the categoy itself.