### PR TITLE
PHP 8 fix to avoid this warning: Undefined array key "input_value"

### DIFF
--- a/woocommerce/inc/wc-qty-btn.php
+++ b/woocommerce/inc/wc-qty-btn.php
@@ -4,7 +4,7 @@
    * WooCommerce Quantity Buttons
    *
    * @package Bootscore
-   * @version 6.2.0
+   * @version 6.3.1
    */
 
 // Exit if accessed directly


### PR DESCRIPTION
Problem: $args[‘input_value’], min_value, max_value are not guaranteed to be assigned > PHP 8 throws notices.

_Warning: Undefined array key "input_value" in \wp-content\themes\bootscore\woocommerce\inc\wc-qty-btn.php on line 31_

The issue happens under php 8.3.2x while trying to reach the checkout.

The added safeguards ensure that meaningful, complete, type-consistent values are always available - regardless of what Woo/plugins deliver - eliminating PHP 8 notices and keeping button states correct.

It works for me. But please test the changes to see if the snippet still works for the cases you have added it for.