### PR TITLE
Incorrect .active states in the Bootstrap navwalker

### DIFF
--- a/inc/navwalker.php
+++ b/inc/navwalker.php
@@ -4,7 +4,7 @@
  * Navwalker
  *
  * @package Bootscore
- * @version 6.3.1
+ * @version 6.4.0
  */
 
 


### PR DESCRIPTION
This change fixes incorrect .active states in the Bootstrap navwalker when WordPress is configured with a static front page and a dedicated “Posts page” (page_for_posts).

In this setup, WordPress can assign current_page_parent to the Posts page menu item not only on blog views, but also on custom post type (CPT) archives and CPT single pages. The previous logic treated current_page_parent as a global “active” signal, which caused the Blog menu item to stay active across unrelated CPT contexts.

The fix keeps WordPress core “current” signals intact, but scopes current_page_parent to contexts where it is semantically reliable:

- normal page hierarchy (is_page() / is_singular('page'))
- the Posts page only when actually in blog context (is_home(), post singles, and standard post archives)

Additionally, CPT archive menu items are made reliably active on both CPT archives and CPT singles generically (without hardcoding CPT slugs), using the menu item’s own post type reference.

In the following screenshot you can see the issue. "Platforma" is a static page, which I assigned with the customizer as blog-page “Posts page” (page_for_posts) and "Team" is a CPT-archive, on wich I was, when I took the screenshot.

<img width="760" height="82" alt="grafik" src="https://github.com/user-attachments/assets/4c9a9319-22bd-4856-948a-370a922060ab" />

Unfortunately I don't have a ready WooCommerce instance for testing it there. So please test it, if all is working as expected. Maybe someone has an idea to make it a bit shorter but it is working for me.