### PR TITLE
Fix: WC reviews `str_replace` breaks `<ol>` in product description

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: Bastian Kreiter, Justin Kruit, Martin Holzer, Tim Groeneveld, Laur
 electronicsandprogramming, charly, Alexandros Kourmoulakis, Sven Geiß, ucalegonte, Benhaim Ido, Sean Emerson, Androidacy, Tamás Dohány,
 David Vanderhaeghe, Karsten Reincke, Patrick Champoux, sweetappleuk, exlexv, Beda Schmid, JWestarp, sir-lexonarkz, xoneill007, 
 Anisur Rahman, Murilo Carvalho, stan1781, MattScarfe, Sarif Hidayat, Hefin Sankala, Michele Grimaldi, Massimo Ghielmi, Little Package, Mateusz Piwek, 
-Fabien Ninollet, Foaly, MarkusKab, Goяo!, neralex, yurii-shchur
+Fabien Ninollet, Foaly, MarkusKab, Goяo!, neralex, yurii-shchur, amansarwar
 
 Tags: featured-images, threaded-comments, translation-ready
 

--- a/woocommerce/inc/wc-single-product-reviews.php
+++ b/woocommerce/inc/wc-single-product-reviews.php
@@ -4,7 +4,7 @@
  * WooCommerce Single Product Reviews
  *
  * @package Bootscore 
- * @version 6.3.1
+ * @version 6.4.0
  */
 
 
@@ -23,14 +23,20 @@ add_action('woocommerce_after_single_product_summary', function () {
   $output = ob_get_clean();
 
   if ($output) {
-    // 1. Replace <div id="comments"> with <div id="woo-comments">
-    $output = str_replace('<div id="comments"', '<div id="woo-comments"', $output);
-
-    // 2. Replace <ol class="commentlist"> with <ul class="comment-list">
+    // First replace the opening tag
     $output = str_replace('<ol class="commentlist">', '<ul class="comment-list">', $output);
-    $output = str_replace('</ol>', '</ul>', $output);
-
-    // 3. Add 'woocommerce-info' class to the verification required message
+    
+    // Use regex to find the commentlist and its matching closing tag
+    // This looks for the commentlist and replaces its closing ol only
+    $output = preg_replace_callback(
+      '/(<ul class="comment-list">.*?)<\/ol>/s',
+      function($matches) {
+        return $matches[1] . '</ul>';
+      },
+      $output
+    );
+    
+    // Add woocommerce-info class to verification message
     $output = str_replace(
       '<p class="woocommerce-verification-required">',
       '<p class="woocommerce-verification-required woocommerce-info">',


### PR DESCRIPTION
@amansarwar, check https://dev.bootscore.me/product/album/#tab-description

Closes https://github.com/bootscore/bootscore/issues/1181