### PR TITLE
apply filters for the subtotal calculation for better compatibility + extend BFcache fix to all browsers

### DIFF
--- a/woocommerce/cart/mini-cart-item.php
+++ b/woocommerce/cart/mini-cart-item.php
@@ -32,9 +32,10 @@
     $thumbnail = apply_filters('woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key);
     $product_price = apply_filters('woocommerce_cart_item_price', WC()->cart->get_product_price($_product), $cart_item, $cart_item_key);
     $product_permalink = apply_filters('woocommerce_cart_item_permalink', $_product->is_visible() ? $_product->get_permalink($cart_item) : '', $cart_item, $cart_item_key);
+    $product_subtotal = apply_filters('woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal($_product, $cart_item['quantity']), $cart_item, $cart_item_key);
     ?>
       <div class="woocommerce-mini-cart-item list-group-item py-3 <?php echo esc_attr(apply_filters('woocommerce_mini_cart_item_class', 'mini_cart_item', $cart_item, $cart_item_key)); ?>"
-           data-bootscore_product_id="<?php echo esc_attr($product_id); ?>" data-key="<?= esc_attr($cart_item_key); ?>">
+           data-bootscore_product_id="<?php echo esc_attr($product_id); ?>" data-key="<?php echo esc_attr($cart_item_key); ?>">
 
         <div class="row g-3">
 
@@ -94,8 +95,11 @@
           <div class="remove col-3 text-end">
 
             <div class="bootscore-custom-render-total h6 mb-4">
-              <?php echo WC()->cart->get_product_subtotal($_product, $cart_item['quantity']); // PHPCS: XSS ok.
+
+                <span>
+              <?php echo $product_subtotal; // PHPCS: XSS ok.
               ?>
+                </span>
             </div>
 
             <?php echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/woocommerce/cart/mini-cart-item.php
+++ b/woocommerce/cart/mini-cart-item.php
@@ -13,7 +13,7 @@
  * @WooCommerce 10.0.0
  *
  * @package Bootscore
- * @version 6.3.1
+ * @version 6.4.0
  */
 
   // Exit if accessed directly

--- a/woocommerce/js/ajax-cart.js
+++ b/woocommerce/js/ajax-cart.js
@@ -351,14 +351,12 @@ jQuery(function ($) {
   });
 
   // 4. Browser Fixes
-  // Chromium-specific fix for browser back button
-  if (window.chrome) {
-    $(window).on('pageshow', function (e) {
-      if (e.originalEvent.persisted) {
-        setTimeout(function () {
-          $(document.body).trigger('wc_fragment_refresh');
-        }, 100);
-      }
-    });
-  }
+  // Refresh fragments when restoring from back-forward cache (BFCache)
+  $(window).on('pageshow', function (e) {
+    if (e.originalEvent && true === e.originalEvent.persisted) {
+      setTimeout(function () {
+        $(document.body).trigger('wc_fragment_refresh');
+      }, 100);
+    }
+  });
 });

--- a/woocommerce/js/ajax-cart.js
+++ b/woocommerce/js/ajax-cart.js
@@ -1,5 +1,5 @@
 /**
- * AJAX Cart JS - Bootscore v6.3.1
+ * AJAX Cart JS - Bootscore v6.4.0
  *
  * Consists of 4 parts
  * 1. Handle Ajax Add to cart


### PR DESCRIPTION
In most cases there was no issue not having that filter applied, but with plugins relying on that filter issues came up. Especially if the same item existed twice in the cart with different subtotals, then both items would get the same subtotal applied. Only visually though. The calculation in the background was fine all the time.