### PR TITLE
Introduce a new `class-update-checker.php`

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -20,6 +20,7 @@ defined('ABSPATH') || exit;
  * 
  * Deprecated, the PUC will be replaced in v7 by the new Bootscore updater
  */
+/*
 require 'inc/update/plugin-update-checker.php';
 use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
 
@@ -31,7 +32,7 @@ $myUpdateChecker = PucFactory::buildUpdateChecker(
 
 // Set the branch that contains the stable release.
 $myUpdateChecker->setBranch('main');
-
+*/
 
 /**
  * Load required files
@@ -103,4 +104,4 @@ if (!class_exists('Bootscore_Update_Checker')) {
 }
 
 // Load theme's own update configuration
-//require_once get_template_directory() . '/inc/updater/updater-config.php';
+require_once get_template_directory() . '/inc/updater/updater-config.php';

--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *
  * @package Bootscore
- * @version 6.4.0
+ * @version 6.5.0
  */
 
 
@@ -17,6 +17,8 @@ defined('ABSPATH') || exit;
 /**
  * Update Checker
  * https://github.com/YahnisElsts/plugin-update-checker
+ * 
+ * Deprecated, the PUC will be replaced in v7 by the new Bootscore updater
  */
 require 'inc/update/plugin-update-checker.php';
 use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
@@ -90,3 +92,15 @@ if (class_exists('WooCommerce')) {
 if (defined('JETPACK__VERSION')) {
   require_once get_template_directory() . '/inc/jetpack.php';
 }
+
+
+/**
+ * Load the shared updater library
+ */
+// Enable the new updater in v7
+if (!class_exists('Bootscore_Update_Checker')) {
+  require_once get_template_directory() . '/inc/updater/class-update-checker.php';
+}
+
+// Load theme's own update configuration
+//require_once get_template_directory() . '/inc/updater/updater-config.php';

--- a/functions.php
+++ b/functions.php
@@ -20,7 +20,6 @@ defined('ABSPATH') || exit;
  * 
  * Deprecated, the PUC will be replaced in v7 by the new Bootscore updater
  */
-/*
 require 'inc/update/plugin-update-checker.php';
 use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
 
@@ -32,7 +31,7 @@ $myUpdateChecker = PucFactory::buildUpdateChecker(
 
 // Set the branch that contains the stable release.
 $myUpdateChecker->setBranch('main');
-*/
+
 
 /**
  * Load required files
@@ -54,6 +53,7 @@ require_once get_template_directory() . '/inc/template-functions.php';      // F
 require_once get_template_directory() . '/inc/widgets.php';                 // Register widget area and disables Gutenberg in widgets
 require_once get_template_directory() . '/inc/deprecated.php';              // Fallback functions being dropped in v6
 require_once get_template_directory() . '/inc/tinymce-editor.php';          // Fix body margin and font-family in backend if classic editor is used
+//require_once get_template_directory() . '/inc/updater/updater-config.php'; // Load theme's own update configuration
 
 // Blocks
 // Patterns
@@ -93,15 +93,3 @@ if (class_exists('WooCommerce')) {
 if (defined('JETPACK__VERSION')) {
   require_once get_template_directory() . '/inc/jetpack.php';
 }
-
-
-/**
- * Load the shared updater library
- */
-// Enable the new updater in v7
-if (!class_exists('Bootscore_Update_Checker')) {
-  require_once get_template_directory() . '/inc/updater/class-update-checker.php';
-}
-
-// Load theme's own update configuration
-require_once get_template_directory() . '/inc/updater/updater-config.php';

--- a/inc/updater/class-update-checker.php
+++ b/inc/updater/class-update-checker.php
@@ -3,8 +3,10 @@
  * Bootscore Update Checker
  * Shared update library for Bootscore products
  * Supports: Custom server (private) + GitHub public releases
+ * 
+ * Inspired by https://rudrastyh.com/wordpress/self-hosted-plugin-update.html
  *
- * @package Bootscore_Update_Checker
+ * @package Bootscore
  * @version 6.5.0
  */
 
@@ -210,10 +212,6 @@ if (!class_exists('Bootscore_Update_Checker')) {
 
       $data = json_decode(wp_remote_retrieve_body($response));
 
-      if (!empty($data) && isset($data->tested)) {
-        $data->tested = $this->normalize_tested_version($data->tested);
-      }
-
       if (!empty($data)) {
         set_transient($cache_key, $data, $this->cache_time);
       }
@@ -379,6 +377,34 @@ if (!class_exists('Bootscore_Update_Checker')) {
     }
 
     /**
+     * Resolve the 'tested' value actually shown/compared against.
+     *
+     * WordPress core compares 'tested' literally against the site's full
+     * running version, both for the Plugins-list "Not tested" badge and the
+     * popup's compatibility warning. If the developer's declared value
+     * already covers the site's version, use it as-is (the honest, accurate
+     * number). Only when the site is running something newer than declared,
+     * fall back to the site's own real, actual version - never an invented
+     * placeholder like '7.0.9', which doesn't correspond to any real release.
+     *
+     * @param string $tested Declared 'tested' value (from readme.txt/info.json)
+     * @return string
+     */
+    private function resolve_tested_version($tested) {
+      $current = get_bloginfo('version');
+
+      if (empty($tested)) {
+        return $current;
+      }
+
+      if (version_compare($current, $tested, '<=')) {
+        return $tested;
+      }
+
+      return $current;
+    }
+
+    /**
      * Get the site's WP version truncated to major.minor (e.g. '7.0.1' -> '7.0'),
      * matching the WordPress convention used for 'Tested up to' declarations.
      *
@@ -388,33 +414,6 @@ if (!class_exists('Bootscore_Update_Checker')) {
       $version = get_bloginfo('version');
       $parts = explode('.', $version);
       return implode('.', array_slice($parts, 0, 2));
-    }
-
-    /**
-     * Pad a major.minor-only 'tested' value (e.g. '7.0') with a high patch
-     * number (e.g. '7.0.9'). WordPress core's own compatibility badge does a
-     * literal version_compare() against the site's full running version, so
-     * a bare '7.0' fails against a running '7.0.1' even though the developer
-     * meant "compatible with the whole 7.0.x line". wp.org's plugin API does
-     * this same padding server-side before core ever sees the value; since
-     * we're not going through wp.org, we do it here instead.
-     *
-     * @param string $tested Raw 'tested' value (e.g. from readme.txt or info.json)
-     * @return string
-     */
-    private function normalize_tested_version($tested) {
-      if (empty($tested)) {
-        return $tested;
-      }
-
-      $parts = explode('.', trim($tested));
-
-      if (count($parts) === 2) {
-        $parts[] = '9';
-        return implode('.', $parts);
-      }
-
-      return $tested;
     }
 
     /**
@@ -578,8 +577,6 @@ if (!class_exists('Bootscore_Update_Checker')) {
         $requires_php = $product->requires_php ?: '7.4';
       }
 
-      $tested = $this->normalize_tested_version($tested);
-
       return (object) array(
         'name' => $product->name,
         'slug' => $product->slug,
@@ -658,7 +655,7 @@ if (!class_exists('Bootscore_Update_Checker')) {
       $res->name = $remote->name ?? $product->name;
       $res->slug = $remote->slug ?? $args->slug;
       $res->version = $remote->version ?? '0.0.0';
-      $res->tested = $remote->tested ?? '';
+      $res->tested = $this->resolve_tested_version($remote->tested ?? '');
       $res->requires = $remote->requires ?? '';
       $res->author = $remote->author ?? '';
       $res->author_profile = $remote->author_profile ?? '';
@@ -713,7 +710,13 @@ if (!class_exists('Bootscore_Update_Checker')) {
         $res->slug = $slug;
         $res->plugin = $product->file;
         $res->new_version = $update->version;
-        $res->tested = $update->tested ?? '';
+        // No automatic padding here - keep 'Tested up to' in readme.txt /
+        // info.json genuinely current instead. WordPress core compares this
+        // value literally against the site's full running version (both for
+        // the Plugins-list "Not tested" badge and the popup warning), so an
+        // accurate, deliberately up-to-date value here satisfies both checks
+        // honestly, with no synthetic values needed.
+        $res->tested = $this->resolve_tested_version($update->tested ?? '');
         $res->package = $update->download_url ?? '';
 
         if (isset($update->requires)) {

--- a/inc/updater/class-update-checker.php
+++ b/inc/updater/class-update-checker.php
@@ -1,0 +1,487 @@
+<?php
+/**
+ * Bootscore Update Checker
+ * Shared update library for Bootscore products
+ * Supports: Custom server (private) + GitHub public releases
+ *
+ * @package Bootscore_Update_Checker
+ * @version 6.5.0
+ */
+
+
+// Exit if accessed directly
+defined('ABSPATH') || exit;
+
+if (!class_exists('Bootscore_Update_Checker')) {
+
+  class Bootscore_Update_Checker {
+
+    /**
+     * @var int Cache duration in seconds
+     */
+    private $cache_time;
+
+    /**
+     * @var array Registered products
+     */
+    private $products = array();
+
+    /**
+     * Constructor
+     *
+     * @param int $cache_time Cache duration in seconds
+     */
+    public function __construct($cache_time = 43200) {
+      $this->cache_time = $cache_time;
+
+      // Hook into WordPress
+      add_filter('plugins_api', array($this, 'plugin_info'), 20, 3);
+      add_filter('site_transient_update_plugins', array($this, 'plugin_updates'));
+      add_filter('pre_set_site_transient_update_themes', array($this, 'theme_updates'));
+      add_action('upgrader_process_complete', array($this, 'clear_cache'), 10, 2);
+    }
+
+    /**
+     * Register a product for updates
+     *
+     * @param array $product {
+     *     @type string 'type'            'plugin' or 'theme'
+     *     @type string 'slug'            Unique product slug
+     *     @type string 'current_version' Current installed version
+     *     @type string 'file'            Plugin file path or theme slug
+     *     @type string 'source'          'custom' or 'github' (default: 'custom')
+     *     @type string 'info_url'        Full URL to info.json (for 'custom' source)
+     *     @type string 'github_repo'     GitHub repo 'owner/repo' (for 'github' source)
+     *     @type string 'name'            Product name
+     * }
+     */
+    public function register_product($product) {
+      $defaults = array(
+        'type' => 'plugin',
+        'slug' => '',
+        'current_version' => '0.0.0',
+        'file' => '',
+        'source' => 'custom', // 'custom' or 'github'
+        'info_url' => '',
+        'github_repo' => '',
+        'name' => '',
+      );
+
+      $product = wp_parse_args($product, $defaults);
+
+      if (empty($product['slug'])) {
+        return;
+      }
+
+      if ($product['source'] === 'custom' && empty($product['info_url'])) {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+          error_log("Bootscore_Update_Checker: missing 'info_url' for product '{$product['slug']}'.");
+        }
+        return;
+      }
+
+      // Auto-detect name if not provided
+      if (empty($product['name'])) {
+        $product['name'] = ucwords(str_replace('-', ' ', $product['slug']));
+      }
+
+      $this->products[$product['slug']] = (object) $product;
+    }
+
+    /**
+     * Get product by slug
+     *
+     * @param string $slug Product slug
+     * @return object|null
+     */
+    private function get_product($slug) {
+      return isset($this->products[$slug]) ? $this->products[$slug] : null;
+    }
+
+    /**
+     * Normalize an 'icons' object from remote data into a plain array,
+     * keeping only the keys WordPress recognizes and that are actually set.
+     *
+     * @param object|null $icons Raw icons object from remote info
+     * @return array
+     */
+    private function format_icons($icons) {
+      if (empty($icons)) {
+        return array();
+      }
+
+      $result = array();
+
+      foreach (array('svg', '2x', '1x', 'default') as $key) {
+        if (!empty($icons->{$key})) {
+          $result[$key] = $icons->{$key};
+        }
+      }
+
+      return $result;
+    }
+
+    /**
+     * Look for icon files bundled in the plugin's own 'assets' folder
+     * (e.g. assets/icon.svg), so icons don't need to be duplicated on
+     * the update server. Only applies to 'plugin' type products.
+     *
+     * @param object $product Product object
+     * @return array
+     */
+    private function get_local_icons($product) {
+      if ($product->type !== 'plugin' || empty($product->file)) {
+        return array();
+      }
+
+      $plugin_file = trailingslashit(WP_PLUGIN_DIR) . $product->file;
+      $plugin_dir = dirname($plugin_file);
+
+      $map = array(
+        'svg' => 'assets/icon.svg',
+      );
+
+      $icons = array();
+
+      foreach ($map as $key => $relative_path) {
+        if (file_exists($plugin_dir . '/' . $relative_path)) {
+          $icons[$key] = plugins_url($relative_path, $plugin_file);
+        }
+      }
+
+      return $icons;
+    }
+
+    /**
+     * Get remote product info - chooses source based on 'source' field
+     *
+     * @param string $slug Product slug
+     * @param bool   $force Force refresh
+     * @return object|null
+     */
+    private function get_remote_info($slug, $force = false) {
+      $product = $this->get_product($slug);
+      if (!$product) {
+        return null;
+      }
+
+      // Route to the appropriate source
+      if ($product->source === 'github') {
+        return $this->get_github_info($slug, $force);
+      }
+
+      // Default: custom server
+      return $this->get_custom_server_info($slug, $force);
+    }
+
+    /**
+     * Get info from custom server (for private repos)
+     *
+     * @param string $slug Product slug
+     * @param bool   $force Force refresh
+     * @return object|null
+     */
+    private function get_custom_server_info($slug, $force = false) {
+      $product = $this->get_product($slug);
+      if (!$product || empty($product->info_url)) {
+        return null;
+      }
+
+      $cache_key = 'bootscore_custom_' . $slug;
+      $cached = get_transient($cache_key);
+
+      if ($cached !== false && !$force) {
+        return $cached;
+      }
+
+      $response = wp_remote_get($product->info_url, array('timeout' => 10));
+
+      if (is_wp_error($response) || 200 !== wp_remote_retrieve_response_code($response)) {
+        return null;
+      }
+
+      $data = json_decode(wp_remote_retrieve_body($response));
+
+      if (!empty($data)) {
+        set_transient($cache_key, $data, $this->cache_time);
+      }
+
+      return $data;
+    }
+
+    /**
+     * Get info from public GitHub API (no token needed!)
+     *
+     * @param string $slug Product slug
+     * @param bool   $force Force refresh
+     * @return object|null
+     */
+    private function get_github_info($slug, $force = false) {
+      $product = $this->get_product($slug);
+
+      // GitHub repo must be set for GitHub source
+      if (empty($product->github_repo)) {
+        return null;
+      }
+
+      $cache_key = 'bootscore_github_' . $slug;
+      $cached = get_transient($cache_key);
+
+      if ($cached !== false && !$force) {
+        return $cached;
+      }
+
+      // GitHub API - NO TOKEN NEEDED for public repos!
+      $url = "https://api.github.com/repos/{$product->github_repo}/releases/latest";
+
+      $response = wp_remote_get($url, array(
+        'timeout' => 10,
+        'headers' => array(
+          'Accept' => 'application/json',
+          'User-Agent' => 'Bootscore-Updater/1.0',
+        ),
+      ));
+
+      if (is_wp_error($response) || 200 !== wp_remote_retrieve_response_code($response)) {
+        return null;
+      }
+
+      $github_data = json_decode(wp_remote_retrieve_body($response));
+
+      if (empty($github_data) || empty($github_data->tag_name)) {
+        return null;
+      }
+
+      // Transform GitHub data to our format
+      $data = $this->format_github_data($github_data, $product);
+
+      set_transient($cache_key, $data, $this->cache_time);
+
+      return $data;
+    }
+
+    /**
+     * Format GitHub release data to our standard format
+     *
+     * @param object $github_data GitHub API response
+     * @param object $product     Product object
+     * @return object
+     */
+    private function format_github_data($github_data, $product) {
+      // Remove 'v' prefix from version if present
+      $tag = ltrim($github_data->tag_name, 'v');
+
+      // Build download URL - look for a .zip asset
+      $download_url = '';
+      if (!empty($github_data->assets)) {
+        foreach ($github_data->assets as $asset) {
+          if (strpos($asset->name, '.zip') !== false) {
+            $download_url = $asset->browser_download_url;
+            break;
+          }
+        }
+      }
+
+      // If no asset found, build standard GitHub download URL
+      if (empty($download_url)) {
+        $download_url = "https://github.com/{$product->github_repo}/releases/download/{$github_data->tag_name}/{$product->slug}.zip";
+      }
+
+      // Extract description from release body
+      $description = $github_data->body ?? 'No description provided.';
+      $changelog = $github_data->body ?? '';
+
+      return (object) array(
+        'name' => $product->name,
+        'slug' => $product->slug,
+        'version' => $tag,
+        'download_url' => $download_url,
+        'tested' => '6.4', // GitHub doesn't provide this, use default
+        'requires' => '5.0', // GitHub doesn't provide this, use default
+        'requires_php' => '7.4', // GitHub doesn't provide this, use default
+        'last_updated' => $github_data->published_at ?? date('Y-m-d H:i:s'),
+        'sections' => array(
+          'description' => $description,
+          'changelog' => $changelog,
+        ),
+        'banners' => array(),
+        'icons' => array(),
+        'homepage' => "https://github.com/{$product->github_repo}",
+      );
+    }
+
+    /**
+     * Check if update is available
+     *
+     * @param string $slug Product slug
+     * @param bool   $force Force check
+     * @return object|false
+     */
+    public function check_for_update($slug, $force = false) {
+      $product = $this->get_product($slug);
+      if (!$product) {
+        return false;
+      }
+
+      $remote = $this->get_remote_info($slug, $force);
+      if (!$remote) {
+        return false;
+      }
+
+      // Check if version is newer
+      if (!version_compare($product->current_version, $remote->version, '<')) {
+        return false;
+      }
+
+      // Check WordPress requirements
+      if (isset($remote->requires) && version_compare(get_bloginfo('version'), $remote->requires, '<')) {
+        return false;
+      }
+
+      // Check PHP requirements
+      if (isset($remote->requires_php) && version_compare(PHP_VERSION, $remote->requires_php, '<')) {
+        return false;
+      }
+
+      return $remote;
+    }
+
+    /**
+     * Plugin info for "View Details" popup
+     */
+    public function plugin_info($res, $action, $args) {
+      if ('plugin_information' !== $action) {
+        return $res;
+      }
+
+      $product = $this->get_product($args->slug);
+      if (!$product || $product->type !== 'plugin') {
+        return $res;
+      }
+
+      $remote = $this->get_remote_info($args->slug);
+      if (!$remote) {
+        return $res;
+      }
+
+      $res = new stdClass();
+      $res->name = $remote->name ?? $product->name;
+      $res->slug = $remote->slug ?? $args->slug;
+      $res->version = $remote->version ?? '0.0.0';
+      $res->tested = $remote->tested ?? '';
+      $res->requires = $remote->requires ?? '';
+      $res->author = $remote->author ?? '';
+      $res->author_profile = $remote->author_profile ?? '';
+      $res->download_link = $remote->download_url ?? '';
+      $res->trunk = $res->download_link;
+      $res->requires_php = $remote->requires_php ?? '';
+      $res->last_updated = $remote->last_updated ?? '';
+
+      $res->sections = array(
+        'description' => $remote->sections->description ?? 'No description available.',
+        'installation' => $remote->sections->installation ?? '',
+        'changelog' => $remote->sections->changelog ?? '',
+      );
+
+      if (!empty($remote->banners)) {
+        $res->banners = array(
+          'low' => $remote->banners->low ?? '',
+          'high' => $remote->banners->high ?? '',
+        );
+      }
+
+      $icons = $this->get_local_icons($product);
+      if (empty($icons)) {
+        $icons = $this->format_icons($remote->icons ?? null);
+      }
+      if (!empty($icons)) {
+        $res->icons = $icons;
+      }
+
+      return $res;
+    }
+
+    /**
+     * Plugin updates
+     */
+    public function plugin_updates($transient) {
+      if (empty($transient->checked)) {
+        return $transient;
+      }
+
+      foreach ($this->products as $slug => $product) {
+        if ($product->type !== 'plugin') {
+          continue;
+        }
+
+        $update = $this->check_for_update($slug);
+        if (!$update) {
+          continue;
+        }
+
+        $res = new stdClass();
+        $res->slug = $slug;
+        $res->plugin = $product->file;
+        $res->new_version = $update->version;
+        $res->tested = $update->tested ?? '';
+        $res->package = $update->download_url ?? '';
+
+        if (isset($update->requires)) {
+          $res->requires = $update->requires;
+        }
+
+        if (isset($update->requires_php)) {
+          $res->requires_php = $update->requires_php;
+        }
+
+        $icons = $this->get_local_icons($product);
+        if (empty($icons)) {
+          $icons = $this->format_icons($update->icons ?? null);
+        }
+        if (!empty($icons)) {
+          $res->icons = $icons;
+        }
+
+        $transient->response[$product->file] = $res;
+      }
+
+      return $transient;
+    }
+
+    /**
+     * Theme updates
+     */
+    public function theme_updates($transient) {
+      foreach ($this->products as $slug => $product) {
+        if ($product->type !== 'theme') {
+          continue;
+        }
+
+        $update = $this->check_for_update($slug);
+        if (!$update) {
+          continue;
+        }
+
+        $transient->response[$slug] = array(
+          'theme' => $slug,
+          'new_version' => $update->version,
+          'package' => $update->download_url ?? '',
+          'url' => $update->homepage ?? '',
+        );
+      }
+
+      return $transient;
+    }
+
+    /**
+     * Clear cache after updates
+     */
+    public function clear_cache() {
+      foreach ($this->products as $slug => $product) {
+        delete_transient('bootscore_custom_' . $slug);
+        delete_transient('bootscore_github_' . $slug);
+        delete_transient('bootscore_update_' . $slug); // Legacy
+      }
+    }
+  }
+}

--- a/inc/updater/class-update-checker.php
+++ b/inc/updater/class-update-checker.php
@@ -12,6 +12,7 @@
 // Exit if accessed directly
 defined('ABSPATH') || exit;
 
+
 if (!class_exists('Bootscore_Update_Checker')) {
 
   class Bootscore_Update_Checker {
@@ -209,6 +210,10 @@ if (!class_exists('Bootscore_Update_Checker')) {
 
       $data = json_decode(wp_remote_retrieve_body($response));
 
+      if (!empty($data) && isset($data->tested)) {
+        $data->tested = $this->normalize_tested_version($data->tested);
+      }
+
       if (!empty($data)) {
         set_transient($cache_key, $data, $this->cache_time);
       }
@@ -374,6 +379,45 @@ if (!class_exists('Bootscore_Update_Checker')) {
     }
 
     /**
+     * Get the site's WP version truncated to major.minor (e.g. '7.0.1' -> '7.0'),
+     * matching the WordPress convention used for 'Tested up to' declarations.
+     *
+     * @return string
+     */
+    private function get_wp_major_minor() {
+      $version = get_bloginfo('version');
+      $parts = explode('.', $version);
+      return implode('.', array_slice($parts, 0, 2));
+    }
+
+    /**
+     * Pad a major.minor-only 'tested' value (e.g. '7.0') with a high patch
+     * number (e.g. '7.0.9'). WordPress core's own compatibility badge does a
+     * literal version_compare() against the site's full running version, so
+     * a bare '7.0' fails against a running '7.0.1' even though the developer
+     * meant "compatible with the whole 7.0.x line". wp.org's plugin API does
+     * this same padding server-side before core ever sees the value; since
+     * we're not going through wp.org, we do it here instead.
+     *
+     * @param string $tested Raw 'tested' value (e.g. from readme.txt or info.json)
+     * @return string
+     */
+    private function normalize_tested_version($tested) {
+      if (empty($tested)) {
+        return $tested;
+      }
+
+      $parts = explode('.', trim($tested));
+
+      if (count($parts) === 2) {
+        $parts[] = '9';
+        return implode('.', $parts);
+      }
+
+      return $tested;
+    }
+
+    /**
      * Fetch a public repo's readme.txt at the exact release tag (not 'main'),
      * so the docs shown always match the version being offered as an update.
      *
@@ -516,7 +560,7 @@ if (!class_exists('Bootscore_Update_Checker')) {
         $changelog = !empty($readme['sections']['changelog'])
           ? $this->markdown_lite_to_html($readme['sections']['changelog'])
           : '';
-        $tested = $product->tested ?: ($readme['tested'] ?: get_bloginfo('version'));
+        $tested = $product->tested ?: ($readme['tested'] ?: $this->get_wp_major_minor());
         $requires = $product->requires ?: ($readme['requires'] ?: '5.0');
         $requires_php = $product->requires_php ?: ($readme['requires_php'] ?: '7.4');
       } else {
@@ -529,10 +573,12 @@ if (!class_exists('Bootscore_Update_Checker')) {
         $changelog = !empty($sections['changelog'])
           ? $this->markdown_lite_to_html($sections['changelog'])
           : '';
-        $tested = $product->tested ?: get_bloginfo('version');
+        $tested = $product->tested ?: $this->get_wp_major_minor();
         $requires = $product->requires ?: '5.0';
         $requires_php = $product->requires_php ?: '7.4';
       }
+
+      $tested = $this->normalize_tested_version($tested);
 
       return (object) array(
         'name' => $product->name,

--- a/inc/updater/class-update-checker.php
+++ b/inc/updater/class-update-checker.php
@@ -53,6 +53,10 @@ if (!class_exists('Bootscore_Update_Checker')) {
      *     @type string 'info_url'        Full URL to info.json (for 'custom' source)
      *     @type string 'github_repo'     GitHub repo 'owner/repo' (for 'github' source)
      *     @type string 'name'            Product name
+     *     @type string 'requires'        Optional min WP version override (GitHub source only;
+     *                                     'custom' source always reads this from info.json)
+     *     @type string 'tested'          Optional "tested up to" WP version override (GitHub source only)
+     *     @type string 'requires_php'    Optional min PHP version override (GitHub source only)
      * }
      */
     public function register_product($product) {
@@ -65,6 +69,9 @@ if (!class_exists('Bootscore_Update_Checker')) {
         'info_url' => '',
         'github_repo' => '',
         'name' => '',
+        'requires' => '',
+        'tested' => '',
+        'requires_php' => '',
       );
 
       $product = wp_parse_args($product, $defaults);
@@ -232,6 +239,8 @@ if (!class_exists('Bootscore_Update_Checker')) {
       }
 
       // GitHub API - NO TOKEN NEEDED for public repos!
+      // Note: /releases/latest already excludes draft and pre-release releases automatically,
+      // so beta/rc tags won't trigger an update unless explicitly published as the latest release.
       $url = "https://api.github.com/repos/{$product->github_repo}/releases/latest";
 
       $response = wp_remote_get($url, array(
@@ -261,6 +270,196 @@ if (!class_exists('Bootscore_Update_Checker')) {
     }
 
     /**
+     * Split a GitHub release body into 'description' and 'changelog' sections,
+     * based on '## Description' / '## Changelog' headings. Falls back to
+     * treating the whole body as the description if no headings are found.
+     *
+     * @param string $body Raw release body (Markdown)
+     * @return array{description: string, changelog: string}
+     */
+    private function parse_release_sections($body) {
+      if (empty($body)) {
+        return array('description' => '', 'changelog' => '');
+      }
+
+      $sections = array();
+
+      if (preg_match_all('/^##\s*(description|changelog)\s*$/im', $body, $matches, PREG_OFFSET_CAPTURE)) {
+        $count = count($matches[0]);
+
+        for ($i = 0; $i < $count; $i++) {
+          $label = strtolower($matches[1][$i][0]);
+          $start = $matches[0][$i][1] + strlen($matches[0][$i][0]);
+          $end = ($i + 1 < $count) ? $matches[0][$i + 1][1] : strlen($body);
+          $sections[$label] = trim(substr($body, $start, $end - $start));
+        }
+      }
+
+      // No recognized headings at all - treat the whole body as the description
+      if (empty($sections)) {
+        return array('description' => trim($body), 'changelog' => '');
+      }
+
+      return array(
+        'description' => $sections['description'] ?? '',
+        'changelog' => $sections['changelog'] ?? '',
+      );
+    }
+
+    /**
+     * Very small Markdown-lite to HTML converter for release note sections.
+     * Handles paragraphs and '- ' / '* ' bullet lists; escapes everything else.
+     *
+     * @param string $text Plain/lite-Markdown text
+     * @return string HTML
+     */
+    private function markdown_lite_to_html($text) {
+      if (empty($text)) {
+        return '';
+      }
+
+      $lines = preg_split('/\r\n|\r|\n/', trim($text));
+      $html = '';
+      $in_list = false;
+
+      foreach ($lines as $line) {
+        $trimmed = trim($line);
+
+        if ($trimmed === '') {
+          continue;
+        }
+
+        // '= Version - Date =' changelog entry heading
+        if (preg_match('/^=\s*(.+?)\s*=$/', $trimmed, $m)) {
+          if ($in_list) {
+            $html .= '</ul>';
+            $in_list = false;
+          }
+          $html .= '<h4>' . esc_html($m[1]) . '</h4>';
+          continue;
+        }
+
+        // '#### Sub heading' style
+        if (preg_match('/^#{2,4}\s*(.+)$/', $trimmed, $m)) {
+          if ($in_list) {
+            $html .= '</ul>';
+            $in_list = false;
+          }
+          $html .= '<h5>' . esc_html($m[1]) . '</h5>';
+          continue;
+        }
+
+        if (preg_match('/^[-*]\s+(.+)$/', $trimmed, $m)) {
+          if (!$in_list) {
+            $html .= '<ul>';
+            $in_list = true;
+          }
+          $html .= '<li>' . esc_html($m[1]) . '</li>';
+          continue;
+        }
+
+        if ($in_list) {
+          $html .= '</ul>';
+          $in_list = false;
+        }
+
+        $html .= '<p>' . esc_html($trimmed) . '</p>';
+      }
+
+      if ($in_list) {
+        $html .= '</ul>';
+      }
+
+      return $html;
+    }
+
+    /**
+     * Fetch a public repo's readme.txt at the exact release tag (not 'main'),
+     * so the docs shown always match the version being offered as an update.
+     *
+     * @param object $product  Product object
+     * @param string $tag_name Raw GitHub tag name (e.g. 'v0.4.0')
+     * @return string|null Raw readme.txt content, or null if unavailable
+     */
+    private function fetch_github_readme($product, $tag_name) {
+      $url = "https://raw.githubusercontent.com/{$product->github_repo}/{$tag_name}/readme.txt";
+
+      $response = wp_remote_get($url, array('timeout' => 10));
+
+      if (is_wp_error($response) || 200 !== wp_remote_retrieve_response_code($response)) {
+        return null;
+      }
+
+      $body = wp_remote_retrieve_body($response);
+
+      return !empty($body) ? $body : null;
+    }
+
+    /**
+     * Parse a standard WordPress-format readme.txt into header fields
+     * (Tested up to / Requires at least / Requires PHP) and sections
+     * (Description / Installation / Changelog).
+     *
+     * @param string|null $readme Raw readme.txt content
+     * @return array|null
+     */
+    private function parse_readme($readme) {
+      if (empty($readme)) {
+        return null;
+      }
+
+      $result = array(
+        'requires' => '',
+        'tested' => '',
+        'requires_php' => '',
+        'sections' => array(
+          'description' => '',
+          'installation' => '',
+          'changelog' => '',
+        ),
+      );
+
+      // '== Section ==' headings only - excludes '=== Title ===' and
+      // '= Changelog entry =' via the [^=] guard right after the opening '=='
+      $heading_pattern = '/^==\s*([^=].*?)\s*==$/m';
+
+      // Header fields (Tested up to, Requires at least, Requires PHP) live
+      // before the first section heading
+      $header = $readme;
+      if (preg_match($heading_pattern, $readme, $first_match, PREG_OFFSET_CAPTURE)) {
+        $header = substr($readme, 0, $first_match[0][1]);
+      }
+
+      if (preg_match('/^\s*Tested up to:\s*(.+)$/im', $header, $m)) {
+        $result['tested'] = trim($m[1]);
+      }
+      if (preg_match('/^\s*Requires at least:\s*(.+)$/im', $header, $m)) {
+        $result['requires'] = trim($m[1]);
+      }
+      if (preg_match('/^\s*Requires PHP:\s*(.+)$/im', $header, $m)) {
+        $result['requires_php'] = trim($m[1]);
+      }
+
+      // Sections
+      if (preg_match_all($heading_pattern, $readme, $matches, PREG_OFFSET_CAPTURE)) {
+        $count = count($matches[0]);
+
+        for ($i = 0; $i < $count; $i++) {
+          $label = strtolower(trim($matches[1][$i][0]));
+          $start = $matches[0][$i][1] + strlen($matches[0][$i][0]);
+          $end = ($i + 1 < $count) ? $matches[0][$i + 1][1] : strlen($readme);
+          $content = trim(substr($readme, $start, $end - $start));
+
+          if (isset($result['sections'][$label])) {
+            $result['sections'][$label] = $content;
+          }
+        }
+      }
+
+      return $result;
+    }
+
+    /**
      * Format GitHub release data to our standard format
      *
      * @param object $github_data GitHub API response
@@ -268,40 +467,85 @@ if (!class_exists('Bootscore_Update_Checker')) {
      * @return object
      */
     private function format_github_data($github_data, $product) {
-      // Remove 'v' prefix from version if present
-      $tag = ltrim($github_data->tag_name, 'v');
+      // Strip a single leading 'v' or 'V' prefix, only when followed by a digit
+      // (e.g. 'v1.2.3' -> '1.2.3', but leaves oddly-named tags alone)
+      $tag = preg_replace('/^[vV](?=\d)/', '', $github_data->tag_name);
 
-      // Build download URL - look for a .zip asset
+      // Build download URL - prefer an asset matching the exact plugin slug,
+      // fall back to the first .zip asset if no exact match is found
       $download_url = '';
       if (!empty($github_data->assets)) {
+        $expected_name = $product->slug . '.zip';
+
         foreach ($github_data->assets as $asset) {
-          if (strpos($asset->name, '.zip') !== false) {
+          if ($asset->name === $expected_name) {
             $download_url = $asset->browser_download_url;
             break;
+          }
+        }
+
+        if (empty($download_url)) {
+          foreach ($github_data->assets as $asset) {
+            if (substr($asset->name, -4) === '.zip') {
+              $download_url = $asset->browser_download_url;
+              break;
+            }
           }
         }
       }
 
       // If no asset found, build standard GitHub download URL
+      // (uses the original, unstripped tag_name, since that's the real tag path)
       if (empty($download_url)) {
         $download_url = "https://github.com/{$product->github_repo}/releases/download/{$github_data->tag_name}/{$product->slug}.zip";
       }
 
-      // Extract description from release body
-      $description = $github_data->body ?? 'No description provided.';
-      $changelog = $github_data->body ?? '';
+      // Prefer the repo's readme.txt at the exact release tag - it's the
+      // standard WP format, includes Installation, and gives real
+      // Tested up to / Requires at least / Requires PHP values.
+      // Falls back to parsing the release notes body if no readme.txt is found.
+      $readme = $this->parse_readme($this->fetch_github_readme($product, $github_data->tag_name));
+
+      if ($readme) {
+        $description = !empty($readme['sections']['description'])
+          ? $this->markdown_lite_to_html($readme['sections']['description'])
+          : 'No description provided.';
+        $installation = !empty($readme['sections']['installation'])
+          ? $this->markdown_lite_to_html($readme['sections']['installation'])
+          : '';
+        $changelog = !empty($readme['sections']['changelog'])
+          ? $this->markdown_lite_to_html($readme['sections']['changelog'])
+          : '';
+        $tested = $product->tested ?: ($readme['tested'] ?: get_bloginfo('version'));
+        $requires = $product->requires ?: ($readme['requires'] ?: '5.0');
+        $requires_php = $product->requires_php ?: ($readme['requires_php'] ?: '7.4');
+      } else {
+        // Split release notes into description/changelog based on ## headings
+        $sections = $this->parse_release_sections($github_data->body ?? '');
+        $description = !empty($sections['description'])
+          ? $this->markdown_lite_to_html($sections['description'])
+          : 'No description provided.';
+        $installation = '';
+        $changelog = !empty($sections['changelog'])
+          ? $this->markdown_lite_to_html($sections['changelog'])
+          : '';
+        $tested = $product->tested ?: get_bloginfo('version');
+        $requires = $product->requires ?: '5.0';
+        $requires_php = $product->requires_php ?: '7.4';
+      }
 
       return (object) array(
         'name' => $product->name,
         'slug' => $product->slug,
         'version' => $tag,
         'download_url' => $download_url,
-        'tested' => '6.4', // GitHub doesn't provide this, use default
-        'requires' => '5.0', // GitHub doesn't provide this, use default
-        'requires_php' => '7.4', // GitHub doesn't provide this, use default
+        'tested' => $tested,
+        'requires' => $requires,
+        'requires_php' => $requires_php,
         'last_updated' => $github_data->published_at ?? date('Y-m-d H:i:s'),
-        'sections' => array(
+        'sections' => (object) array(
           'description' => $description,
+          'installation' => $installation,
           'changelog' => $changelog,
         ),
         'banners' => array(),

--- a/inc/updater/updater-config.php
+++ b/inc/updater/updater-config.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Bootscore Theme Update Configuration
+ * Registers ONLY the theme for updates from GitHub
+ * 
+ * @package Bootscore
+ * @version 6.5.0
+ */
+
+
+// Exit if accessed directly.
+defined('ABSPATH') || exit;
+
+
+// Initialize the updater (no URL needed for GitHub-only setup)
+global $bootscore_updater;
+
+if (!isset($bootscore_updater)) {
+  $bootscore_updater = new Bootscore_Update_Checker('', 12 * HOUR_IN_SECONDS);
+}
+
+// --- REGISTER THEME FROM GITHUB PUBLIC REPO ---
+$theme = wp_get_theme('bootscore');
+
+$bootscore_updater->register_product(array(
+  'type' => 'theme',
+  'slug' => 'bootscore',
+  'current_version' => $theme->get('Version') ?? '1.0.0',
+  'file' => 'update-theme-public-repo',
+  'source' => 'github',
+  'github_repo' => 'bopotscore/bootscore',
+  'name' => 'Bootscore',
+));

--- a/inc/updater/updater-config.php
+++ b/inc/updater/updater-config.php
@@ -2,7 +2,7 @@
 /**
  * Bootscore Theme Update Configuration
  * Registers ONLY the theme for updates from GitHub
- * 
+ *
  * @package Bootscore
  * @version 6.5.0
  */
@@ -12,22 +12,36 @@
 defined('ABSPATH') || exit;
 
 
-// Initialize the updater (no URL needed for GitHub-only setup)
-global $bootscore_updater;
+add_action('init', function() {
+  global $bootscore_updater;
 
-if (!isset($bootscore_updater)) {
-  $bootscore_updater = new Bootscore_Update_Checker('', 12 * HOUR_IN_SECONDS);
-}
+  // Ensure the class is loaded (fallback in case functions.php didn't already load it)
+  if (!class_exists('Bootscore_Update_Checker')) {
+    $class_path = get_template_directory() . '/inc/updater/class-update-checker.php';
+    if (file_exists($class_path)) {
+      require_once $class_path;
+    }
+  }
 
-// --- REGISTER THEME FROM GITHUB PUBLIC REPO ---
-$theme = wp_get_theme('bootscore');
+  // Initialize if needed
+  if (!isset($bootscore_updater) && class_exists('Bootscore_Update_Checker')) {
+    $bootscore_updater = new Bootscore_Update_Checker(12 * HOUR_IN_SECONDS);
+  }
 
-$bootscore_updater->register_product(array(
-  'type' => 'theme',
-  'slug' => 'bootscore',
-  'current_version' => $theme->get('Version') ?? '1.0.0',
-  'file' => 'update-theme-public-repo',
-  'source' => 'github',
-  'github_repo' => 'bopotscore/bootscore',
-  'name' => 'Bootscore',
-));
+  // Bail if updater still isn't available
+  if (!isset($bootscore_updater) || !class_exists('Bootscore_Update_Checker')) {
+    return;
+  }
+
+  // --- REGISTER THEME FROM GITHUB PUBLIC REPO ---
+  $theme = wp_get_theme('bootscore');
+
+  $bootscore_updater->register_product(array(
+    'type' => 'theme',
+    'slug' => 'bootscore',
+    'current_version' => $theme->get('Version') ?: '1.0.0',
+    'source' => 'github',
+    'github_repo' => 'bopotscore/bootscore', // TODO: confirm this is the correct org/repo
+    'name' => 'Bootscore',
+  ));
+});


### PR DESCRIPTION
This new updater will replace the entire PUC library in the long-term. For now it's used by the commercial plugins which access is broken to GitHub releases.

AI generated docs:

# Bootscore Update Checker

A shared, self-contained update library for Bootscore products (theme and plugins). One class file, loaded once, used by any number of products — no per-product duplication of update-checking code.

Supports two update sources:

- **Custom server** — a private `info.json` file you host yourself (e.g. for commercial plugins)
- **Public GitHub releases** — reads directly from a public repo's GitHub Releases and `readme.txt`, no access token needed

---

## How it works

`class-update-checker.php` only *defines* the `Bootscore_Update_Checker` class. Nothing happens until something instantiates it and registers a product. This makes the file completely safe to include anywhere, at any time — if it's never instantiated, it's inert.

Every consumer (theme or plugin) is expected to:

1. Make sure the class is loaded (with a fallback, in case nothing else has loaded it yet)
2. Instantiate the shared `$bootscore_updater` global, if it doesn't already exist
3. Call `register_product()` with its own details

All of this happens inside an `add_action('init', ...)` callback — **not** at top-level file-include time. This avoids load-order issues between the theme and plugins (WordPress plugins load before the theme's `functions.php`, so relying on top-level code being "instantiated by whoever loads first" is fragile).

Because every consumer carries its own fallback, **the theme does not need to explicitly load `class-update-checker.php` in `functions.php`.** It's safe to do so for clarity/early-loading, but not required.

---

## Registering a product

`register_product()` accepts:

| Key | Required | Notes |
|---|---|---|
| `type` | yes | `'plugin'` or `'theme'` |
| `slug` | yes | Unique per product. **Must not be reused across products** — sharing a slug means one registration silently overwrites the other. |
| `current_version` | yes | Usually read from the plugin/theme header |
| `file` | plugins only | `plugin_basename(...)` of the main plugin file |
| `source` | yes | `'custom'` or `'github'` |
| `info_url` | `custom` source only | Full, direct URL to `info.json` |
| `github_repo` | `github` source only | `'owner/repo'` |
| `name` | no | Auto-generated from `slug` if omitted |
| `requires` | no, `github` only | Min WP version override. `custom` source always reads this from `info.json`. |
| `tested` | no, `github` only | "Tested up to" override. Falls back to the repo's `readme.txt`, then the site's own WP version. |
| `requires_php` | no, `github` only | Min PHP version override |

**Important:** `slug` must be unique across *all* registered products sharing the same `$bootscore_updater` instance (theme + every plugin on the same site). Copy-pasting a config from one product to another without updating the slug will cause one product's registration to silently overwrite the other's.

---

## Case 1 — Plugin, private server (`info.json`)

Used for commercial plugins hosted on your own server.

**`inc/updater-config.php`** (required by the plugin's main file):

```php
<?php
defined('ABSPATH') || exit;

global $bootscore_updater;

// Ensure the class is loaded
if (!class_exists('Bootscore_Update_Checker')) {
  $theme_path = get_template_directory() . '/inc/updater/class-update-checker.php';
  if (file_exists($theme_path)) {
    require_once $theme_path;
  }
}

// Initialize if class exists
if (!isset($bootscore_updater) && class_exists('Bootscore_Update_Checker')) {
  $bootscore_updater = new Bootscore_Update_Checker(12 * HOUR_IN_SECONDS);
}

// Only proceed if updater is ready
if (!isset($bootscore_updater) || !class_exists('Bootscore_Update_Checker')) {
  return; // Silent fail if updater not available
}

add_action('init', function() {
  global $bootscore_updater;

  if (!class_exists('Bootscore_Update_Checker') || !$bootscore_updater) {
    return;
  }

  $plugin_file = dirname(__DIR__) . '/main.php';

  if (!file_exists($plugin_file)) {
    return;
  }

  $plugin_data = get_file_data(
    $plugin_file,
    array('Version' => 'Version')
  );

  $bootscore_updater->register_product(array(
    'type' => 'plugin',
    'slug' => 'bs-example-plugin',
    'current_version' => $plugin_data['Version'] ?? '1.0',
    'file' => plugin_basename($plugin_file),
    'source' => 'custom',
    'info_url' => 'https://files.bootscore.me/plugins/bs-example-plugin-XXXX-XXXX/info.json',
    'name' => 'bs Example Plugin',
  ));
});
```

**`info.json`** (hosted at the `info_url` above):

```json
{
  "name" : "bs Example Plugin",
  "slug" : "bs-example-plugin",
  "author" : "<a href='https://bootscore.me'>Bootscore</a>",
  "author_profile" : "https://bootscore.me",
  "version" : "1.3.0",
  "download_url" : "https://files.bootscore.me/plugins/bs-example-plugin-XXXX-XXXX/bs-example-plugin.zip",
  "requires" : "5.0",
  "tested" : "7.0",
  "requires_php" : "7.4",
  "last_updated" : "2026-06-19",
  "sections" : {
    "description" : "<h4>bs Example Plugin</h4><p>Plugin description here.</p>",
    "installation" : "<h4>Installation</h4><ol><li>In your admin panel, go to Plugins &gt; and click the Add New button.</li><li>Click Upload Plugin and Choose File, then select the Plugin's .zip file. Click Install Now.</li><li>Click Activate to use your new Plugin right away.</li></ol>",
    "changelog" : "<h4>Changelog</h4><p>You can find a detailed changelog in the readme.txt file in the plugin's root directory.</p>"
  },
  "banners" : {
    "low" : "https://files.bootscore.me/plugins/banner_sm.png",
    "high" : "https://files.bootscore.me/plugins/banner_lg.png"
  }
}
```

**Icons:** if the plugin ships `assets/icon.svg` in its own folder, it's used automatically — no `icons` field needed in `info.json`. Only add an `icons` block to `info.json` if you want a server-hosted fallback:

```json
"icons" : {
  "svg" : "https://files.bootscore.me/plugins/bs-example-plugin-XXXX-XXXX/icon.svg"
}
```

---

## Case 2 — Plugin, public GitHub release

Used for free plugins with public repos. No token required.

**`inc/updater-config.php`:**

```php
<?php
defined('ABSPATH') || exit;

add_action('init', function() {
  global $bootscore_updater;

  // Ensure the class is loaded
  if (!class_exists('Bootscore_Update_Checker')) {
    $theme_path = get_template_directory() . '/inc/updater/class-update-checker.php';
    if (file_exists($theme_path)) {
      require_once $theme_path;
    }
  }

  // Initialize if needed
  if (!isset($bootscore_updater) && class_exists('Bootscore_Update_Checker')) {
    $bootscore_updater = new Bootscore_Update_Checker(12 * HOUR_IN_SECONDS);
  }

  if (!isset($bootscore_updater) || !class_exists('Bootscore_Update_Checker')) {
    return;
  }

  $plugin_file = dirname(__DIR__) . '/main.php';

  if (!file_exists($plugin_file)) {
    return;
  }

  $plugin_data = get_file_data(
    $plugin_file,
    array('Version' => 'Version')
  );

  $bootscore_updater->register_product(array(
    'type' => 'plugin',
    'slug' => 'bs-example-free-plugin',
    'current_version' => $plugin_data['Version'] ?? '1.0',
    'file' => plugin_basename($plugin_file),
    'source' => 'github',
    'github_repo' => 'bootscore/bs-example-free-plugin',
    'name' => 'bs Example Free Plugin',
  ));
});
```

**No `info.json` needed.** Instead, the plugin's repo should contain a standard WordPress-format `readme.txt` at its root:

```
=== bs Example Free Plugin ===
Stable tag: 1.3.0
Tested up to: 7.0
Requires at least: 5.0
Requires PHP: 7.4
License: MIT License
License URI: license-url

== Description ==
This is the long description. Supports basic Markdown-lite: paragraphs and `- ` bullet lists.

== Installation ==
1. In your admin panel, go to Plugins > and click the Add New button.
2. Click Upload Plugin and Choose File, then select the Plugin's .zip file. Click Install Now.
3. Click Activate to use your new Plugin right away.

== Changelog ==
= 1.3.0 - June 19 2026 =
#### Bugfix
- Fixed a bug
#### Update
- Added icon.svg

= 1.2.0 - May 21 2026 =
#### Updates
- Some update
```

**How it's resolved, in order:**
1. The GitHub Release's zip asset — an asset named exactly `{slug}.zip` is preferred; falls back to the first `.zip` asset found, then to the standard `https://github.com/{repo}/releases/download/{tag}/{slug}.zip` pattern.
2. `readme.txt` fetched at the **exact release tag** (not `main`) provides the Description / Installation / Changelog tabs and the `Tested up to` / `Requires at least` / `Requires PHP` values.
3. If no `readme.txt` is found, falls back to parsing the GitHub Release's own description box, if it contains `## Description` / `## Changelog` headings.
4. If neither is available: sensible defaults (`5.0` / `7.4` / site's own WP version).

**Version tags:** a leading `v`/`V` is stripped automatically (`v1.3.0` → `1.3.0`).

**Icons:** same as Case 1 — `assets/icon.svg` bundled in the plugin is used automatically.

---

## Case 3 — Theme, private server (`info.json`)

Same pattern as Case 1, just `'type' => 'theme'` and no `file` key (unused for themes).

**`inc/updater/updater-config.php`:**

```php
<?php
defined('ABSPATH') || exit;

global $bootscore_updater;

if (!class_exists('Bootscore_Update_Checker')) {
  $class_path = get_template_directory() . '/inc/updater/class-update-checker.php';
  if (file_exists($class_path)) {
    require_once $class_path;
  }
}

if (!isset($bootscore_updater) && class_exists('Bootscore_Update_Checker')) {
  $bootscore_updater = new Bootscore_Update_Checker(12 * HOUR_IN_SECONDS);
}

if (!isset($bootscore_updater) || !class_exists('Bootscore_Update_Checker')) {
  return;
}

add_action('init', function() {
  global $bootscore_updater;

  if (!class_exists('Bootscore_Update_Checker') || !$bootscore_updater) {
    return;
  }

  $theme = wp_get_theme('bootscore');

  $bootscore_updater->register_product(array(
    'type' => 'theme',
    'slug' => 'bootscore',
    'current_version' => $theme->get('Version') ?: '1.0.0',
    'source' => 'custom',
    'info_url' => 'https://files.bootscore.me/themes/bootscore/info.json',
    'name' => 'Bootscore',
  ));
});
```

**`inc/theme-setup.php` / `functions.php`:**

```php
// Load theme's own update configuration
require_once get_template_directory() . '/inc/updater/updater-config.php';
```

This one line is the only thing that needs to run unconditionally — everything else (class loading, instantiation) is self-contained inside `updater-config.php`.

**`info.json`:** same structure as Case 1, adjusted for the theme (theme screenshots can be used as banners if desired).

---

## Case 4 — Theme, public GitHub release

**`inc/updater/updater-config.php`:**

```php
<?php
defined('ABSPATH') || exit;

add_action('init', function() {
  global $bootscore_updater;

  if (!class_exists('Bootscore_Update_Checker')) {
    $class_path = get_template_directory() . '/inc/updater/class-update-checker.php';
    if (file_exists($class_path)) {
      require_once $class_path;
    }
  }

  if (!isset($bootscore_updater) && class_exists('Bootscore_Update_Checker')) {
    $bootscore_updater = new Bootscore_Update_Checker(12 * HOUR_IN_SECONDS);
  }

  if (!isset($bootscore_updater) || !class_exists('Bootscore_Update_Checker')) {
    return;
  }

  $theme = wp_get_theme('bootscore');

  $bootscore_updater->register_product(array(
    'type' => 'theme',
    'slug' => 'bootscore',
    'current_version' => $theme->get('Version') ?: '1.0.0',
    'source' => 'github',
    'github_repo' => 'bootscore/bootscore',
    'name' => 'Bootscore',
  ));
});
```

```php
// functions.php
require_once get_template_directory() . '/inc/updater/updater-config.php';
```

**No `info.json` needed** — same `readme.txt`-first resolution as Case 2 applies. The theme's own `screenshot.png` (standard WordPress theme convention) is used automatically for the theme details screen; no separate icon/banner config needed.

---

## Cache & clearing

Remote data is cached in WordPress transients for the duration passed to the constructor (`12 * HOUR_IN_SECONDS` in all examples above):

- Custom server: `bootscore_custom_{slug}`
- GitHub: `bootscore_github_{slug}`

Cache is cleared automatically after any update is installed (`upgrader_process_complete`). To force a fresh check manually during development/testing:

```
wp transient delete bootscore_custom_bs-example-plugin
wp transient delete bootscore_github_bs-example-free-plugin
```

**Note:** clicking "Check Again" on the WordPress Updates screen does **not** clear these transients — only a genuine plugin/theme install does. Delete the transient manually when testing changes to `info.json` or a GitHub release/readme.

---

## Migration note (PUC → this updater)

This library and the [PluginUpdateChecker (PUC)](https://github.com/YahnisElsts/plugin-update-checker) library can coexist safely during migration, since:

- `class-update-checker.php` only defines a class; it does nothing until instantiated
- Each system only writes to the transient/`plugins_api` response entries for the products *it* has registered — there's no shared state for products registered with only one system

**Do not** register the same plugin with both systems at the same time — migrate one plugin fully (add this updater's config, remove the old PUC init) before moving to the next.