### PR TITLE
Namespace submit handler, scope wp_loaded removal to AJAX requests

### DIFF
--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -95,8 +95,26 @@
     add_action('wc_ajax_ace_add_to_cart', 'bootscore_ajax_add_to_cart_handler');
     add_action('wc_ajax_nopriv_ace_add_to_cart', 'bootscore_ajax_add_to_cart_handler');
 
-    // Remove WC Core add to cart handler to prevent double-add
-    remove_action('wp_loaded', array('WC_Form_Handler', 'add_to_cart_action'), 20);
+    /**
+     * Remove the WooCommerce core add to cart handler to prevent a double-add,
+     * but only while our own AJAX endpoint is the one being served.
+     *
+     * WC_AJAX::do_wc_ajax() runs on template_redirect (priority 0), while
+     * WC_Form_Handler::add_to_cart_action() runs on wp_loaded (priority 20), so the
+     * decision can be deferred until the requested endpoint is known. Removing it
+     * unconditionally would also disable the native (non-AJAX) form POST, leaving no
+     * working fallback for forms that opt out of the JS handler.
+     */
+    function bootscore_maybe_remove_wc_add_to_cart_action() {
+      // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only reads the endpoint name, no data is processed here.
+      $wc_ajax_endpoint = isset($_GET['wc-ajax']) ? sanitize_text_field(wp_unslash($_GET['wc-ajax'])) : '';
+
+      if ('ace_add_to_cart' === $wc_ajax_endpoint) {
+        remove_action('wp_loaded', array('WC_Form_Handler', 'add_to_cart_action'), 20);
+      }
+    }
+
+    add_action('wp_loaded', 'bootscore_maybe_remove_wc_add_to_cart_action', 19);
 
 
     /**

--- a/woocommerce/inc/ajax-cart.php
+++ b/woocommerce/inc/ajax-cart.php
@@ -4,7 +4,7 @@
    * WooCommerce AJAX cart
    *
    * @package Bootscore
-   * @version 6.4.0
+   * @version 6.5.0
    */
 
 

--- a/woocommerce/js/ajax-cart.js
+++ b/woocommerce/js/ajax-cart.js
@@ -16,7 +16,9 @@ jQuery(function ($) {
   // 1 Handle AJAX Add To Cart
 
   // 1.1 Enable AJAX for single product pages
-  $('form.cart').on('submit', function (e) {
+  // The handler is namespaced so third parties can unbind it in a supported way:
+  // $('form.cart').off('submit.bootscoreAjaxAddToCart');
+  $('form.cart').on('submit.bootscoreAjaxAddToCart', function (e) {
     // Only apply to single product pages, not external products
     if (!$(this).closest('.product-type-external').length) {
       e.preventDefault();

--- a/woocommerce/js/ajax-cart.js
+++ b/woocommerce/js/ajax-cart.js
@@ -1,5 +1,5 @@
 /**
- * AJAX Cart JS - Bootscore v6.4.0
+ * AJAX Cart JS - Bootscore v6.5.0
  *
  * Consists of 4 parts
  * 1. Handle Ajax Add to cart


### PR DESCRIPTION
Addresses requests **(a)** and **(c)** of #1234.

### (a) Namespace the single-product submit handler

`woocommerce/js/ajax-cart.js` now binds `submit.bootscoreAjaxAddToCart` instead of a bare `submit`, matching the precedent already set by the loop handler's `click.bootscoreAjaxAddToCart`.

Third parties can unbind it in a supported way:

```js
$('form.cart').off('submit.bootscoreAjaxAddToCart');
```

instead of walking the private `$._data()` API and string-matching `ace_add_to_cart` inside the handler body, which silently stops matching if the endpoint is ever renamed.

No behaviour change.

### (c) Scope the `wp_loaded` removal to actual AJAX requests

`woocommerce/inc/ajax-cart.php` removed `WC_Form_Handler::add_to_cart_action` globally and unconditionally, which also disabled the native (non-AJAX) form POST site-wide — so opting out of the JS handler left nothing working to fall back to.

The removal is now deferred into a `wp_loaded` callback at priority 19 that only fires when `ace_add_to_cart` is the endpoint being served. `WC_AJAX::do_wc_ajax()` runs on `template_redirect` (priority 0) while `add_to_cart_action` runs on `wp_loaded` (priority 20), so the requested endpoint is known in time.

Double-add protection on the AJAX route is unchanged; every other request keeps a working native form POST.

The priority-19 hook registers in time because `ajax-cart.php` is required on `after_setup_theme`. `WC_AJAX::get_endpoint()` always builds the URL as a `wc-ajax` query arg, so the `$_GET` check is reliable — there is no rewrite-based path to the endpoint.

### Not included

Requests (b) opt-out attribute, (d) cancelable event and (e) documentation are not part of this PR. Happy to follow up on any of them.

Closes https://github.com/bootscore/bootscore/issues/1234
