### PR TITLE
v7: Add `text-break` as a filterable body class

### DIFF
--- a/assets/scss/bootscore/_deprecated.scss
+++ b/assets/scss/bootscore/_deprecated.scss
@@ -17,19 +17,6 @@ Deprecated - Bootscore v7.0.0. This code will be removed in v7.
 }
 
 
-body {
-  // Prevent horizontal scrollbars on Windows Chrome & Firefox when using width-100 class
-  overflow-x: hidden;
-  
-  // This is mandatory for the WP Theme Unit Test Data
-  // https://dev.bootscore.me/about/page-markup-and-formatting/
-  // Breaks responsive tables
-  word-break: break-word;
-  
-  // If we keep both, we can just use Bootstrap classes
-  // <?= esc_attr(apply_filters('bootscore/class/body', 'overflow-x-hidden text-break')); ?>
-  // And check responsive tables
-}
 
 // Responsive Tables
 // Theme uses word-break: break-word; on body as recommended by WordPress to handle edge cases.

--- a/assets/scss/bootscore/_deprecated.scss
+++ b/assets/scss/bootscore/_deprecated.scss
@@ -1,5 +1,5 @@
 /*--------------------------------------------------------------
-Deprecated - Bootscore v7.0.0. This code will be removed in v7.
+Deprecated - Bootscore v7.0.0. This code will be removed.
 --------------------------------------------------------------*/
 
 
@@ -17,25 +17,6 @@ Deprecated - Bootscore v7.0.0. This code will be removed in v7.
 }
 
 
-
-// Responsive Tables
-// Theme uses word-break: break-word; on body as recommended by WordPress to handle edge cases.
-// See https://dev.bootscore.me/2009/10/05/title-should-not-overflow-the-content-area/
-// As result, words break in tables and responsive tables aren't responsive.
-// Adding white-space: nowrap; to tables to each breakpoint solves this.
-@each $breakpoint in map-keys($grid-breakpoints) {
-  $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
-
-  @include media-breakpoint-down($breakpoint) {
-    .table-responsive#{$infix} {
-      .table {
-        white-space: nowrap;
-      }
-    }
-  }
-}
-
-
 // Responsive image height in (new) cards-horizontal.php loop card template
 // Class h-100 creates issue with bs Swiper v6 in mobile view
 // Recheck this in v7. If we keep it, move it to utilities.scss
@@ -47,7 +28,6 @@ Deprecated - Bootscore v7.0.0. This code will be removed in v7.
 
 
 // Check if Bootstrap v6 will have a backdrop-blur utility https://github.com/orgs/twbs/discussions/42187
-
 .backdrop-blur-10 {
   backdrop-filter: blur(10px) saturate(180%);
   -webkit-backdrop-filter: blur(10px) saturate(180%);

--- a/functions.php
+++ b/functions.php
@@ -18,6 +18,7 @@ defined('ABSPATH') || exit;
  * Load required files
  */
 require_once get_template_directory() . '/inc/theme-setup.php';             // Theme setup and custom theme supports
+require_once get_template_directory() . '/inc/body.php';                    // Required WP body classes
 require_once get_template_directory() . '/inc/breadcrumb.php';              // Breadcrumb
 require_once get_template_directory() . '/inc/columns.php';                 // Main/sidebar column width and breakpoints
 require_once get_template_directory() . '/inc/comments.php';                // Comments

--- a/inc/blocks/block-table.php
+++ b/inc/blocks/block-table.php
@@ -4,7 +4,7 @@
  * Block Table
  *
  * @package Bootscore
- * @version 6.3.1
+ * @version 7.0.0
  */
 
 
@@ -30,7 +30,7 @@ if (!function_exists('bootscore_block_table_classes')) {
       '<table'
     );
     $replace = array(
-      'table-responsive',
+      'table-responsive text-nowrap', // text-nowrap because tables inherits text-wrap from <body>
       '<table class="table ' . esc_attr(apply_filters('bootscore/class/block/table', '')) . '"'
     );
     

--- a/inc/body.php
+++ b/inc/body.php
@@ -15,11 +15,6 @@ defined('ABSPATH') || exit;
 /**
  * word-break: break-word is required for the WP Theme Unit Test Data
  * https://dev.bootscore.me/about/page-markup-and-formatting/
- *
- * Change class:
- * add_filter( 'bootscore/class/body', function( $class ) {
- *   return 'my-custom-class';
- * });
  */
 function bootscore_wp_body_class( $classes ) {
 

--- a/inc/body.php
+++ b/inc/body.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Required WP classes on <body>
+ *
+ * @package Bootscore
+ * @version 7.0.0
+ */
+
+
+// Exit if accessed directly
+defined('ABSPATH') || exit;
+
+
+/**
+ * word-break: break-word is required for the WP Theme Unit Test Data
+ * https://dev.bootscore.me/about/page-markup-and-formatting/
+ *
+ * Change class:
+ * add_filter( 'bootscore/class/body', function( $class ) {
+ *   return 'my-custom-class';
+ * });
+ */
+function bootscore_wp_body_class( $classes ) {
+
+  $classes[] = apply_filters( 'bootscore/class/body', 'text-break' );
+
+  return $classes;
+}
+add_filter( 'body_class', 'bootscore_wp_body_class' );


### PR DESCRIPTION

```php
 add_filter( 'bootscore/class/body', function( $class ) {
    return 'text-break bg-success;
 });