### PR TITLE
v7: Refactor loop templates to stretched link

### DIFF
--- a/template-parts/loop/cards-grid.php
+++ b/template-parts/loop/cards-grid.php
@@ -32,7 +32,7 @@ $context = 'cards-grid';
 
   <div class="<?= esc_attr(apply_filters('bootscore/class/loop/card/body', 'card-body h-100 d-flex flex-column', 'cards-grid')); ?>">
 
-    <div class="<?= esc_attr(apply_filters('bootscore/class/loop/card/content/meta-wrapper', 'd-flex justify-content-between gap-3', 'cards-grid')); ?>">
+    <div class="<?= esc_attr(apply_filters('bootscore/class/loop/card/content/meta-wrapper', 'd-flex justify-content-between gap-3 z-2', 'cards-grid')); ?>">
 
       <?php if (apply_filters('bootscore/loop/category', true, 'cards-grid')) : ?>
         <?php bootscore_category_badge(); ?>
@@ -69,16 +69,16 @@ $context = 'cards-grid';
       </p>
     <?php endif; ?>
 
-    <?php if (apply_filters('bootscore/loop/read-more', true, 'cards-grid')) : ?>
-      <p class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/read-more', 'card-text mt-auto', 'cards-grid')); ?>">
-        <a class="read-more <?= esc_attr(apply_filters('bootscore/class/loop/read-more', 'stretched-link', 'cards-grid')); ?>" href="<?php the_permalink(); ?>">
-          <?= wp_kses_post(apply_filters('bootscore/loop/read-more/text', __('Read more »', 'bootscore'), 'cards-grid')); ?>
-        </a>
-      </p>
-    <?php endif; ?>
+    <p class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/read-more', 'card-text mt-auto', 'cards-grid')); ?>">
+      <a class="read-more <?= esc_attr(apply_filters('bootscore/class/loop/read-more', 'stretched-link', 'cards-grid')); ?>" href="<?php the_permalink(); ?>">
+        <?= wp_kses_post(apply_filters('bootscore/loop/read-more/text', __('Read more »', 'bootscore'), 'cards-grid')); ?>
+      </a>
+    </p>
 
     <?php if (apply_filters('bootscore/loop/tags', true, 'cards-grid') && has_tag()) : ?>
-      <?php bootscore_tags(); ?>
+      <div class="z-2">
+        <?php bootscore_tags(); ?>
+      </div>
     <?php endif; ?>
 
     <?php do_action('bootscore_after_loop_tags', 'cards-grid'); ?>

--- a/template-parts/loop/cards-grid.php
+++ b/template-parts/loop/cards-grid.php
@@ -25,9 +25,7 @@ $context = 'cards-grid';
   <?php do_action('bootscore_before_loop_thumbnail', 'cards-grid'); ?>
     
   <?php if ( has_post_thumbnail() ) : ?>
-    <a href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
-      <?php the_post_thumbnail('medium', array('class' => esc_attr(apply_filters('bootscore/class/loop/card/image', 'card-img-top', 'cards-grid')))); ?>
-    </a>
+    <?php the_post_thumbnail('medium', array('class' => esc_attr(apply_filters('bootscore/class/loop/card/image', 'card-img-top', 'cards-grid')))); ?>
   <?php endif; ?>
 
   <?php do_action('bootscore_after_loop_thumbnail', 'cards-grid'); ?>
@@ -48,15 +46,13 @@ $context = 'cards-grid';
 
     <?php do_action('bootscore_before_loop_title', 'cards-grid'); ?>
     
-    <a class="<?= esc_attr(apply_filters('bootscore/class/loop/card/title/link', 'text-body text-decoration-none', 'cards-grid')); ?>" href="<?php the_permalink(); ?>">
-      <?php the_title('<h2 class="' . esc_attr(apply_filters('bootscore/class/loop/card/title', 'h5', 'cards-grid')) . '">', '</h2>'); ?>
-    </a>
+    <?php the_title('<h2 class="' . esc_attr(apply_filters('bootscore/class/loop/card/title', 'h5', 'cards-grid')) . '">', '</h2>'); ?>
    
     <?php do_action('bootscore_after_loop_title', 'cards-grid'); ?>
 
     <?php if (apply_filters('bootscore/loop/meta', true, 'cards-grid')) : ?>
       <?php if ('post' === get_post_type()) : ?>
-        <p class="meta small mb-2 text-body-secondary">
+        <p class="meta small mb-2 text-body-secondary z-2">
           <?php
           bootscore_date();
           bootscore_author();
@@ -68,16 +64,14 @@ $context = 'cards-grid';
     <?php endif; ?>
     
     <?php if (apply_filters('bootscore/loop/excerpt', true, 'cards-grid')) : ?>
-      <p class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/excerpt', 'card-text', 'cards-grid')); ?>">
-        <a class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/excerpt/link', 'text-body text-decoration-none', 'cards-grid')); ?>" href="<?php the_permalink(); ?>">                
-          <?php bootscore_excerpt(); ?>
-        </a>
+      <p class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/excerpt', 'card-text', 'cards-grid')); ?>">            
+        <?php bootscore_excerpt(); ?>
       </p>
     <?php endif; ?>
 
     <?php if (apply_filters('bootscore/loop/read-more', true, 'cards-grid')) : ?>
       <p class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/read-more', 'card-text mt-auto', 'cards-grid')); ?>">
-        <a class="<?= esc_attr(apply_filters('bootscore/class/loop/read-more', 'read-more', 'cards-grid')); ?>" href="<?php the_permalink(); ?>">
+        <a class="read-more <?= esc_attr(apply_filters('bootscore/class/loop/read-more', 'stretched-link', 'cards-grid')); ?>" href="<?php the_permalink(); ?>">
           <?= wp_kses_post(apply_filters('bootscore/loop/read-more/text', __('Read more »', 'bootscore'), 'cards-grid')); ?>
         </a>
       </p>

--- a/template-parts/loop/cards-horizontal.php
+++ b/template-parts/loop/cards-horizontal.php
@@ -59,7 +59,7 @@ $context = 'cards-horizontal';
 
         <?php if (apply_filters('bootscore/loop/meta', true, 'cards-horizontal')) : ?>
           <?php if ('post' === get_post_type()) : ?>
-            <p class="meta small mb-2 text-body-secondary z-3">
+            <p class="meta small mb-2 text-body-secondary z-2">
               <?php
               bootscore_date();
               bootscore_author();

--- a/template-parts/loop/cards-horizontal.php
+++ b/template-parts/loop/cards-horizontal.php
@@ -30,9 +30,7 @@ $context = 'cards-horizontal';
 
     <?php if (has_post_thumbnail()) : ?>
       <div class="<?= esc_attr(apply_filters('bootscore/class/loop/card/image/col', 'col-md-5 col-lg-6 col-xl-5 col-xxl-4', 'cards-horizontal')); ?>">
-        <a href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
-          <?php the_post_thumbnail('medium', array('class' => esc_attr(apply_filters('bootscore/class/loop/card/image', 'h-md-100 object-fit-md-cover', 'cards-horizontal')))); ?>
-        </a>
+        <?php the_post_thumbnail('medium', array('class' => esc_attr(apply_filters('bootscore/class/loop/card/image', 'h-md-100 object-fit-md-cover', 'cards-horizontal')))); ?>
       </div>
     <?php endif; ?>
 
@@ -55,15 +53,13 @@ $context = 'cards-horizontal';
 
         <?php do_action('bootscore_before_loop_title', 'cards-horizontal'); ?>
 
-        <a class="<?= esc_attr(apply_filters('bootscore/class/loop/card/title/link', 'text-body text-decoration-none', 'cards-horizontal')); ?>" href="<?php the_permalink(); ?>">
-          <?php the_title('<h2 class="' . esc_attr(apply_filters('bootscore/class/loop/card/title', 'h5', 'cards-horizontal')) . '">', '</h2>'); ?>
-        </a>
+        <?php the_title('<h2 class="' . esc_attr(apply_filters('bootscore/class/loop/card/title', 'h5', 'cards-horizontal')) . '">', '</h2>'); ?>
         
         <?php do_action('bootscore_after_loop_title', 'cards-horizontal'); ?>
 
         <?php if (apply_filters('bootscore/loop/meta', true, 'cards-horizontal')) : ?>
           <?php if ('post' === get_post_type()) : ?>
-            <p class="meta small mb-2 text-body-secondary">
+            <p class="meta small mb-2 text-body-secondary z-3">
               <?php
               bootscore_date();
               bootscore_author();
@@ -76,19 +72,15 @@ $context = 'cards-horizontal';
         
         <?php if (apply_filters('bootscore/loop/excerpt', true, 'cards-horizontal')) : ?>
           <p class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/excerpt', 'card-text', 'cards-horizontal')); ?>">
-            <a class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/excerpt/link', 'text-body text-decoration-none', 'cards-horizontal')); ?>" href="<?php the_permalink(); ?>">                
-              <?php bootscore_excerpt(); ?>
-            </a>
+            <?php bootscore_excerpt(); ?>
           </p>
         <?php endif; ?>
         
-        <?php if (apply_filters('bootscore/loop/read-more', true, 'cards-horizontal')) : ?>
-          <p class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/read-more', 'card-text mt-auto', 'cards-horizontal')); ?>">
-            <a class="<?= esc_attr(apply_filters('bootscore/class/loop/read-more', 'read-more', 'cards-horizontal')); ?>" href="<?php the_permalink(); ?>">
-              <?= wp_kses_post(apply_filters('bootscore/loop/read-more/text', __('Read more »', 'bootscore'), 'cards-horizontal')); ?>
-            </a>
-          </p>
-        <?php endif; ?>
+        <p class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/read-more', 'card-text mt-auto', 'cards-horizontal')); ?>">
+          <a class="read-more <?= esc_attr(apply_filters('bootscore/class/loop/read-more', 'stretched-link', 'cards-horizontal')); ?>" href="<?php the_permalink(); ?>">
+            <?= wp_kses_post(apply_filters('bootscore/loop/read-more/text', __('Read more »', 'bootscore'), 'cards-horizontal')); ?>
+          </a>
+        </p>
 
         <?php if (apply_filters('bootscore/loop/tags', true, 'cards-horizontal') && has_tag()) : ?>
           <?php bootscore_tags(); ?>

--- a/template-parts/loop/cards-horizontal.php
+++ b/template-parts/loop/cards-horizontal.php
@@ -39,7 +39,7 @@ $context = 'cards-horizontal';
     <div class="<?= esc_attr(apply_filters('bootscore/class/loop/card/content/col', 'col', 'cards-horizontal')); ?>">
       <div class="<?= esc_attr(apply_filters('bootscore/class/loop/card/body', 'card-body h-100 d-flex flex-column', 'cards-horizontal')); ?>">
 
-        <div class="<?= esc_attr(apply_filters('bootscore/class/loop/card/content/meta-wrapper', 'd-flex justify-content-between gap-3', 'cards-horizontal')); ?>">
+        <div class="<?= esc_attr(apply_filters('bootscore/class/loop/card/content/meta-wrapper', 'd-flex justify-content-between gap-3 z-2', 'cards-horizontal')); ?>">
 
           <?php if (apply_filters('bootscore/loop/category', true, 'cards-horizontal')) : ?>
             <?php bootscore_category_badge(); ?>
@@ -83,7 +83,9 @@ $context = 'cards-horizontal';
         </p>
 
         <?php if (apply_filters('bootscore/loop/tags', true, 'cards-horizontal') && has_tag()) : ?>
-          <?php bootscore_tags(); ?>
+          <div class="z-2">
+            <?php bootscore_tags(); ?>
+          </div>
         <?php endif; ?>
 
         <?php do_action('bootscore_after_loop_tags', 'cards-horizontal'); ?>

--- a/template-parts/loop/cards-overlay.php
+++ b/template-parts/loop/cards-overlay.php
@@ -24,9 +24,7 @@ $context = 'cards-overlay';
   <?php do_action('bootscore_before_loop_thumbnail', 'cards-overlay'); ?>
     
   <?php if ( has_post_thumbnail() ) : ?>
-    <a href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
-      <?php the_post_thumbnail('full', array('class' => esc_attr(apply_filters('bootscore/class/loop/card/image', 'card-img', 'cards-overlay')))); ?>
-    </a>
+    <?php the_post_thumbnail('full', array('class' => esc_attr(apply_filters('bootscore/class/loop/card/image', 'card-img', 'cards-overlay')))); ?>
   <?php endif; ?>
 
   <?php do_action('bootscore_after_loop_thumbnail', 'cards-overlay'); ?>
@@ -35,7 +33,7 @@ $context = 'cards-overlay';
 
     <div class="<?= esc_attr(apply_filters('bootscore/class/loop/card/img-overlay/content/wrapper', 'bg-body bg-opacity-50 backdrop-blur-10 rounded-3 p-3 mt-auto', 'cards-overlay')); ?>">
       
-      <div class="<?= esc_attr(apply_filters('bootscore/class/loop/card/content/meta-wrapper', 'd-flex justify-content-between gap-3', 'cards-overlay')); ?>">
+      <div class="<?= esc_attr(apply_filters('bootscore/class/loop/card/content/meta-wrapper', 'd-flex justify-content-between gap-3 position-relative z-2', 'cards-overlay')); ?>">
 
         <?php if (apply_filters('bootscore/loop/category', true, 'cards-overlay')) : ?>
           <?php bootscore_category_badge(); ?>
@@ -49,15 +47,13 @@ $context = 'cards-overlay';
 
       <?php do_action('bootscore_before_loop_title', 'cards-overlay'); ?>
 
-      <a class="<?= esc_attr(apply_filters('bootscore/class/loop/card/title/link', 'text-body text-decoration-none', 'cards-overlay')); ?>" href="<?php the_permalink(); ?>">
-        <?php the_title('<h2 class="' . esc_attr(apply_filters('bootscore/class/loop/card/title', 'h5', 'cards-overlay')) . '">', '</h2>'); ?>
-      </a>
+      <?php the_title('<h2 class="' . esc_attr(apply_filters('bootscore/class/loop/card/title', 'h5', 'cards-overlay')) . '">', '</h2>'); ?>
       
       <?php do_action('bootscore_after_loop_title', 'cards-overlay'); ?>
 
       <?php if (apply_filters('bootscore/loop/meta', true, 'cards-overlay')) : ?>
         <?php if ('post' === get_post_type()) : ?>
-          <p class="meta small mb-2 text-body-secondary">
+          <p class="meta small mb-2 text-body-secondary position-relative z-2">
             <?php
             bootscore_date();
             bootscore_author();
@@ -70,22 +66,20 @@ $context = 'cards-overlay';
       
       <?php if (apply_filters('bootscore/loop/excerpt', true, 'cards-overlay')) : ?>
         <p class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/excerpt', 'card-text', 'cards-overlay')); ?>">
-          <a class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/excerpt/link', 'text-body text-decoration-none', 'cards-overlay')); ?>" href="<?php the_permalink(); ?>">                
-            <?php bootscore_excerpt(); ?>
-          </a>
+          <?php bootscore_excerpt(); ?>
         </p>
       <?php endif; ?>
 
-      <?php if (apply_filters('bootscore/loop/read-more', true, 'cards-overlay')) : ?>
-        <p class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/read-more', 'card-text mt-auto', 'cards-overlay')); ?>">
-          <a class="<?= esc_attr(apply_filters('bootscore/class/loop/read-more', 'read-more', 'cards-overlay')); ?>" href="<?php the_permalink(); ?>">
-            <?= wp_kses_post(apply_filters('bootscore/loop/read-more/text', __('Read more »', 'bootscore'), 'cards-overlay')); ?>
-          </a>
-        </p>
-      <?php endif; ?>
+      <p class="<?= esc_attr(apply_filters('bootscore/class/loop/card-text/read-more', 'card-text mt-auto', 'cards-overlay')); ?>">
+        <a class="read-more <?= esc_attr(apply_filters('bootscore/class/loop/read-more', 'stretched-link', 'cards-overlay')); ?>" href="<?php the_permalink(); ?>">
+          <?= wp_kses_post(apply_filters('bootscore/loop/read-more/text', __('Read more »', 'bootscore'), 'cards-overlay')); ?>
+        </a>
+      </p>
 
       <?php if (apply_filters('bootscore/loop/tags', true, 'cards-overlay') && has_tag()) : ?>
-        <?php bootscore_tags(); ?>
+        <div class="position-relative z-2">
+          <?php bootscore_tags(); ?>
+        </div>
       <?php endif; ?>
 
       <?php do_action('bootscore_after_loop_tags', 'cards-overlay'); ?>


### PR DESCRIPTION
Deleted filters:

bootscore/class/loop/card/title/link
bootscore/class/loop/card-text/excerpt/link
bootscore/loop/read-more